### PR TITLE
fix(transactions): split-transaction validator parity (#42)

### DIFF
--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-unsupported-features/es-builtins */
 import {
   BulkTransactions,
   CreateTransactions,
@@ -7,51 +8,108 @@ import {
 import {IsValidString} from "../stringUtils";
 import {isValidMetaData} from "./ledgerBalance";
 
-/**
- * Resolves the numeric total used for split-leg distribution checks.
- * When both `amount` and `precise_amount` are provided, `amount` takes precedence
- * to match the API's primary amount field for distribution math.
- */
-function resolveTransactionAmount(
-  data: CreateTransactions<Record<string, unknown>>,
-): number | null {
-  const hasAmount = typeof data.amount === `number`;
-  const hasPreciseAmount = typeof data.precise_amount === `number`;
+const NON_NEGATIVE_INTEGER_STRING = /^\d+$/;
 
-  if (!hasAmount && !hasPreciseAmount) {
+type TransactionTotal =
+  | {arithmetic: `number`; value: number}
+  | {arithmetic: `bigint`; value: bigint};
+
+/**
+ * Parses a non-negative integer for precise amount/distribution fields.
+ * Uses BigInt so string values larger than Number.MAX_SAFE_INTEGER stay exact.
+ */
+function parsePreciseInteger(value: string | number): bigint | null {
+  if (typeof value === `number`) {
+    if (!Number.isFinite(value) || value < 0 || !Number.isInteger(value)) {
+      return null;
+    }
+    return BigInt(value);
+  }
+
+  const trimmed = value.trim();
+  if (!NON_NEGATIVE_INTEGER_STRING.test(trimmed)) {
     return null;
   }
 
-  if (hasAmount) {
-    return data.amount as number;
+  try {
+    return BigInt(trimmed);
+  } catch {
+    return null;
   }
-
-  return data.precise_amount as number;
-}
-
-function parsePreciseDistribution(value: string | number): number | null {
-  if (typeof value === `number`) {
-    if (!Number.isFinite(value) || value < 0) {
-      return null;
-    }
-    return value;
-  }
-
-  if (typeof value === `string` && value.trim() !== ``) {
-    const parsed = Number(value.trim());
-    if (!Number.isFinite(parsed) || parsed < 0) {
-      return null;
-    }
-    return parsed;
-  }
-
-  return null;
 }
 
 function hasPreciseDistribution(leg: MultipleSourcesT): boolean {
   return (
     leg.precise_distribution !== undefined && leg.precise_distribution !== null
   );
+}
+
+function usesPreciseIntegerArithmetic(
+  data: CreateTransactions<Record<string, unknown>>,
+): boolean {
+  if (data.sources?.some(hasPreciseDistribution)) {
+    return true;
+  }
+  if (data.destinations?.some(hasPreciseDistribution)) {
+    return true;
+  }
+  if (typeof data.precise_amount === `string`) {
+    return true;
+  }
+  if (
+    data.precise_amount !== undefined &&
+    data.precise_amount !== null &&
+    typeof data.amount !== `number`
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Resolves the transaction total for split-leg distribution checks.
+ * When both `amount` and `precise_amount` are provided, `amount` takes precedence.
+ */
+function resolveTransactionTotal(
+  data: CreateTransactions<Record<string, unknown>>,
+): TransactionTotal | null {
+  const hasAmount = typeof data.amount === `number`;
+  const hasPreciseAmount =
+    data.precise_amount !== undefined && data.precise_amount !== null;
+
+  if (!hasAmount && !hasPreciseAmount) {
+    return null;
+  }
+
+  if (usesPreciseIntegerArithmetic(data)) {
+    if (hasAmount) {
+      return {
+        arithmetic: `bigint`,
+        value: BigInt(Math.trunc(data.amount as number)),
+      };
+    }
+
+    const parsed = parsePreciseInteger(data.precise_amount as string | number);
+    if (parsed === null) {
+      return null;
+    }
+    return {arithmetic: `bigint`, value: parsed};
+  }
+
+  if (hasAmount) {
+    return {arithmetic: `number`, value: data.amount as number};
+  }
+
+  const parsed = parsePreciseInteger(data.precise_amount as string | number);
+  if (parsed === null) {
+    return null;
+  }
+
+  if (parsed <= BigInt(Number.MAX_SAFE_INTEGER)) {
+    return {arithmetic: `number`, value: Number(parsed)};
+  }
+
+  return {arithmetic: `bigint`, value: parsed};
 }
 
 function validateSplitLegRouting(
@@ -96,8 +154,15 @@ function validateSplitLegRouting(
 export function ValidateCreateTransactions<T extends Record<string, unknown>>(
   data: CreateTransactions<T>,
 ): string | null {
-  const transactionAmount = resolveTransactionAmount(data);
-  if (transactionAmount === null) {
+  const transactionTotal = resolveTransactionTotal(data);
+  if (transactionTotal === null) {
+    if (
+      data.precise_amount !== undefined &&
+      data.precise_amount !== null &&
+      typeof data.amount !== `number`
+    ) {
+      return `precise_amount must be a non-negative integer string or number.`;
+    }
     return `Either 'amount' or 'precise_amount' must be provided.`;
   }
 
@@ -105,11 +170,16 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
     return `Amount must be a number.`;
   }
 
-  if (
-    data.precise_amount !== undefined &&
-    typeof data.precise_amount !== `number`
-  ) {
-    return `precise_amount must be a number.`;
+  if (data.precise_amount !== undefined && data.precise_amount !== null) {
+    const isValidPreciseAmount =
+      typeof data.precise_amount === `number` ||
+      typeof data.precise_amount === `string`;
+    if (!isValidPreciseAmount) {
+      return `precise_amount must be a string or number.`;
+    }
+    if (parsePreciseInteger(data.precise_amount) === null) {
+      return `precise_amount must be a non-negative integer string or number.`;
+    }
   }
 
   if (typeof data.precision !== `number`) {
@@ -141,7 +211,7 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
   if (data.sources) {
     const sourcesError = validateSplitLegs(
       data.sources,
-      transactionAmount,
+      transactionTotal,
       `source`,
     );
     if (sourcesError) return sourcesError;
@@ -150,7 +220,7 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
   if (data.destinations) {
     const destinationsError = validateSplitLegs(
       data.destinations,
-      transactionAmount,
+      transactionTotal,
       `destination`,
     );
     if (destinationsError) return destinationsError;
@@ -195,7 +265,7 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
 
 function validateSplitLegs(
   legs: MultipleSourcesT[],
-  amount: number,
+  total: TransactionTotal,
   legLabel: `source` | `destination`,
 ): string | null {
   const legArrayName = legLabel === `source` ? `sources` : `destinations`;
@@ -227,19 +297,23 @@ function validateSplitLegs(
     }
   }
 
-  return validateDistributionLegs(legs, amount);
+  if (total.arithmetic === `bigint`) {
+    return validateDistributionLegsBigInt(legs, total.value);
+  }
+
+  return validateDistributionLegsNumber(legs, total.value);
 }
 
-function validateDistributionLegs(
+function validateDistributionLegsBigInt(
   legs: MultipleSourcesT[],
-  amount: number,
+  total: bigint,
 ): string | null {
-  let sum = 0;
+  let sum = BigInt(0);
   let hasLeft = false;
 
   for (const leg of legs) {
     if (hasPreciseDistribution(leg)) {
-      const preciseValue = parsePreciseDistribution(leg.precise_distribution!);
+      const preciseValue = parsePreciseInteger(leg.precise_distribution!);
       if (preciseValue === null) {
         return `Invalid precise_distribution for leg: ${leg.identifier}.`;
       }
@@ -247,6 +321,53 @@ function validateDistributionLegs(
       continue;
     }
 
+    const distribution = leg.distribution;
+    if (!distribution || !IsValidString(distribution)) {
+      return `Invalid distribution type for leg: ${leg.identifier}.`;
+    }
+
+    if (distribution.endsWith(`%`)) {
+      const percentageValue = parseFloat(distribution.slice(0, -1));
+      if (
+        isNaN(percentageValue) ||
+        percentageValue < 0 ||
+        percentageValue > 100
+      ) {
+        return `Invalid percentage value in leg: ${leg.identifier}.`;
+      }
+      sum += (total * BigInt(Math.trunc(percentageValue))) / BigInt(100);
+    } else if (NON_NEGATIVE_INTEGER_STRING.test(distribution)) {
+      sum += BigInt(distribution);
+    } else if (distribution === `left`) {
+      if (hasLeft) {
+        return `Multiple 'left' distribution types are not allowed.`;
+      }
+      hasLeft = true;
+    } else {
+      return `Invalid distribution type for leg: ${leg.identifier}.`;
+    }
+  }
+
+  if (hasLeft) {
+    const remaining = total - sum;
+    if (remaining < BigInt(0)) {
+      return `Total distribution exceeds the specified amount.`;
+    }
+  } else if (sum !== total) {
+    return `Total distribution sum (${sum}) does not equal the specified amount (${total}).`;
+  }
+
+  return null;
+}
+
+function validateDistributionLegsNumber(
+  legs: MultipleSourcesT[],
+  amount: number,
+): string | null {
+  let sum = 0;
+  let hasLeft = false;
+
+  for (const leg of legs) {
     const distribution = leg.distribution;
     if (!distribution || !IsValidString(distribution)) {
       return `Invalid distribution type for leg: ${leg.identifier}.`;

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -7,12 +7,85 @@ import {
 import {IsValidString} from "../stringUtils";
 import {isValidMetaData} from "./ledgerBalance";
 
+/**
+ * Resolves the numeric total used for split-leg distribution checks.
+ * API accepts either `amount` or `precise_amount` (see create-transaction reference).
+ */
+function resolveTransactionAmount(
+  data: CreateTransactions<Record<string, unknown>>,
+): number | null {
+  const hasAmount = typeof data.amount === `number`;
+  const hasPreciseAmount = typeof data.precise_amount === `number`;
+
+  if (!hasAmount && !hasPreciseAmount) {
+    return null;
+  }
+
+  if (hasAmount) {
+    return data.amount as number;
+  }
+
+  return data.precise_amount as number;
+}
+
+function validateSplitLegRouting(
+  data: CreateTransactions<Record<string, unknown>>,
+): string | null {
+  const hasSource = Boolean(data.source);
+  const hasSources = Boolean(data.sources && data.sources.length > 0);
+  const hasDestination = Boolean(data.destination);
+  const hasDestinations = Boolean(
+    data.destinations && data.destinations.length > 0,
+  );
+
+  if (hasSource && hasSources) {
+    return `Both 'source' and 'sources' cannot be provided together.`;
+  }
+
+  if (hasDestination && hasDestinations) {
+    return `Both 'destination' and 'destinations' cannot be provided together.`;
+  }
+
+  if (hasSources) {
+    if (hasDestinations) {
+      return `'sources' requires a single 'destination'; use 'destination' instead of 'destinations'.`;
+    }
+    if (!hasDestination) {
+      return `'destination' is required when using 'sources'.`;
+    }
+  }
+
+  if (hasDestinations) {
+    if (hasSources) {
+      return `'destinations' requires a single 'source'; use 'source' instead of 'sources'.`;
+    }
+    if (!hasSource) {
+      return `'source' is required when using 'destinations'.`;
+    }
+  }
+
+  return null;
+}
+
 export function ValidateCreateTransactions<T extends Record<string, unknown>>(
   data: CreateTransactions<T>,
 ): string | null {
-  if (typeof data.amount !== `number`) {
+  const transactionAmount = resolveTransactionAmount(data);
+  if (transactionAmount === null) {
+    return `Either 'amount' or 'precise_amount' must be provided.`;
+  }
+
+  if (data.amount !== undefined && typeof data.amount !== `number`) {
     return `Amount must be a number.`;
   }
+
+  if (
+    data.precise_amount !== undefined &&
+    typeof data.precise_amount !== `number`
+  ) {
+    return `precise_amount must be a number.`;
+  }
+
   if (typeof data.precision !== `number`) {
     return `Precision must be a number.`;
   }
@@ -26,13 +99,9 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
     return `Invalid currency.`;
   }
 
-  if (data.source && data.sources) {
-    return `Both 'source' and 'sources' cannot be provided together.`;
-  }
-
-  if (data.sources) {
-    const sourcesError = validateSources(data.sources, data.amount);
-    if (sourcesError) return sourcesError;
+  const splitLegError = validateSplitLegRouting(data);
+  if (splitLegError) {
+    return splitLegError;
   }
 
   if (data.source && typeof data.source !== `string`) {
@@ -43,12 +112,21 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
     return `Destination must be a string.`;
   }
 
-  if (data.destination && data.destinations) {
-    return `Both 'source' and 'sources' cannot be provided together.`;
+  if (data.sources) {
+    const sourcesError = validateSplitLegs(
+      data.sources,
+      transactionAmount,
+      `source`,
+    );
+    if (sourcesError) return sourcesError;
   }
 
   if (data.destinations) {
-    const destinationsError = validateSources(data.destinations, data.amount);
+    const destinationsError = validateSplitLegs(
+      data.destinations,
+      transactionAmount,
+      `destination`,
+    );
     if (destinationsError) return destinationsError;
   }
 
@@ -82,12 +160,32 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
     return `Allow overdraft must be a boolean if provided.`;
   }
 
-  // Validate meta_data if provided
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
   }
 
-  return null; // No errors
+  return null;
+}
+
+function validateSplitLegs(
+  legs: MultipleSourcesT[],
+  amount: number,
+  legLabel: `source` | `destination`,
+): string | null {
+  if (!Array.isArray(legs) || legs.length === 0) {
+    return `'${legLabel === `source` ? `sources` : `destinations`}' must be a non-empty array.`;
+  }
+
+  for (const leg of legs) {
+    if (!IsValidString(leg.identifier)) {
+      return `Each ${legLabel} leg must include a valid identifier.`;
+    }
+    if (!IsValidString(leg.distribution)) {
+      return `Each ${legLabel} leg must include a valid distribution.`;
+    }
+  }
+
+  return validateSources(legs, amount);
 }
 
 function validateSources(
@@ -145,17 +243,14 @@ export function ValidateUpdateTransactions<T extends Record<string, unknown>>(
     return `Status must be a string.`;
   }
 
-  //if amount exists, it must be a number
   if (data.amount !== undefined && typeof data.amount !== `number`) {
     return `Amount must be a number.`;
   }
 
-  // Validate meta_data if provided
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
   }
 
-  //if any field not  in the type is provided, throw an error
   const allowedFields = [`status`, `amount`, `meta_data`];
   for (const key in data) {
     if (!allowedFields.includes(key)) {
@@ -169,22 +264,18 @@ export function ValidateUpdateTransactions<T extends Record<string, unknown>>(
 export function ValidateBulkTransactions<T extends Record<string, unknown>>(
   data: BulkTransactions<T>,
 ): string | null {
-  // Validate atomic field
   if (data.atomic !== undefined && typeof data.atomic !== `boolean`) {
     return `Atomic must be a boolean if provided.`;
   }
 
-  // Validate inflight field
   if (data.inflight !== undefined && typeof data.inflight !== `boolean`) {
     return `Inflight must be a boolean if provided.`;
   }
 
-  // Validate run_async field
   if (data.run_async !== undefined && typeof data.run_async !== `boolean`) {
     return `Run_async must be a boolean if provided.`;
   }
 
-  // Validate transactions array
   if (!Array.isArray(data.transactions)) {
     return `Transactions must be an array.`;
   }
@@ -193,7 +284,6 @@ export function ValidateBulkTransactions<T extends Record<string, unknown>>(
     return `Transactions array cannot be empty.`;
   }
 
-  // Validate each transaction in the array
   for (let i = 0; i < data.transactions.length; i++) {
     const transaction = data.transactions[i];
     const validationError = ValidateCreateTransactions(transaction);
@@ -202,7 +292,6 @@ export function ValidateBulkTransactions<T extends Record<string, unknown>>(
     }
   }
 
-  // Validate reference uniqueness within the batch
   const references = data.transactions.map(t => t.reference);
   const uniqueReferences = new Set(references);
   if (references.length !== uniqueReferences.size) {

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -9,7 +9,8 @@ import {isValidMetaData} from "./ledgerBalance";
 
 /**
  * Resolves the numeric total used for split-leg distribution checks.
- * API accepts either `amount` or `precise_amount` (see create-transaction reference).
+ * When both `amount` and `precise_amount` are provided, `amount` takes precedence
+ * to match the API's primary amount field for distribution math.
  */
 function resolveTransactionAmount(
   data: CreateTransactions<Record<string, unknown>>,
@@ -26,6 +27,31 @@ function resolveTransactionAmount(
   }
 
   return data.precise_amount as number;
+}
+
+function parsePreciseDistribution(value: string | number): number | null {
+  if (typeof value === `number`) {
+    if (!Number.isFinite(value) || value < 0) {
+      return null;
+    }
+    return value;
+  }
+
+  if (typeof value === `string` && value.trim() !== ``) {
+    const parsed = Number(value.trim());
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return null;
+    }
+    return parsed;
+  }
+
+  return null;
+}
+
+function hasPreciseDistribution(leg: MultipleSourcesT): boolean {
+  return (
+    leg.precise_distribution !== undefined && leg.precise_distribution !== null
+  );
 }
 
 function validateSplitLegRouting(
@@ -172,31 +198,59 @@ function validateSplitLegs(
   amount: number,
   legLabel: `source` | `destination`,
 ): string | null {
+  const legArrayName = legLabel === `source` ? `sources` : `destinations`;
+
   if (!Array.isArray(legs) || legs.length === 0) {
-    return `'${legLabel === `source` ? `sources` : `destinations`}' must be a non-empty array.`;
+    return `'${legArrayName}' must be a non-empty array.`;
   }
 
   for (const leg of legs) {
     if (!IsValidString(leg.identifier)) {
       return `Each ${legLabel} leg must include a valid identifier.`;
     }
-    if (!IsValidString(leg.distribution)) {
-      return `Each ${legLabel} leg must include a valid distribution.`;
+
+    const hasDistribution =
+      leg.distribution !== undefined && leg.distribution !== null;
+    const hasPreciseDistributionValue = hasPreciseDistribution(leg);
+
+    if (!hasDistribution && !hasPreciseDistributionValue) {
+      return `Each ${legLabel} leg must include either 'distribution' or 'precise_distribution'.`;
+    }
+
+    if (
+      hasPreciseDistributionValue &&
+      leg.precise_distribution !== undefined &&
+      typeof leg.precise_distribution !== `string` &&
+      typeof leg.precise_distribution !== `number`
+    ) {
+      return `precise_distribution must be a string or number for leg: ${leg.identifier}.`;
     }
   }
 
-  return validateSources(legs, amount);
+  return validateDistributionLegs(legs, amount);
 }
 
-function validateSources(
-  sources: MultipleSourcesT[],
+function validateDistributionLegs(
+  legs: MultipleSourcesT[],
   amount: number,
 ): string | null {
   let sum = 0;
   let hasLeft = false;
 
-  for (const source of sources) {
-    const {distribution} = source;
+  for (const leg of legs) {
+    if (hasPreciseDistribution(leg)) {
+      const preciseValue = parsePreciseDistribution(leg.precise_distribution!);
+      if (preciseValue === null) {
+        return `Invalid precise_distribution for leg: ${leg.identifier}.`;
+      }
+      sum += preciseValue;
+      continue;
+    }
+
+    const distribution = leg.distribution;
+    if (!distribution || !IsValidString(distribution)) {
+      return `Invalid distribution type for leg: ${leg.identifier}.`;
+    }
 
     if (distribution.endsWith(`%`)) {
       const percentageValue = parseFloat(distribution.slice(0, -1));
@@ -205,13 +259,13 @@ function validateSources(
         percentageValue < 0 ||
         percentageValue > 100
       ) {
-        return `Invalid percentage value in source: ${source.identifier}`;
+        return `Invalid percentage value in leg: ${leg.identifier}.`;
       }
       sum += (percentageValue / 100) * amount;
     } else if (!isNaN(Number(distribution))) {
       const numericValue = parseFloat(distribution);
       if (numericValue < 0) {
-        return `Invalid numeric value in source: ${source.identifier}`;
+        return `Invalid numeric value in leg: ${leg.identifier}.`;
       }
       sum += numericValue;
     } else if (distribution === `left`) {
@@ -220,7 +274,7 @@ function validateSources(
       }
       hasLeft = true;
     } else {
-      return `Invalid distribution type for source: ${source.identifier}`;
+      return `Invalid distribution type for leg: ${leg.identifier}.`;
     }
   }
 

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -2,7 +2,7 @@ export interface CreateTransactions<T extends Record<string, unknown>> {
   /** Human-readable amount. Provide `amount` or `precise_amount` (at least one). */
   amount?: number;
   /** Amount after precision is applied. Provide `amount` or `precise_amount` (at least one). */
-  precise_amount?: number;
+  precise_amount?: number | string;
   precision: number;
   reference: string;
   description: string;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,5 +1,8 @@
 export interface CreateTransactions<T extends Record<string, unknown>> {
-  amount: number;
+  /** Human-readable amount. Provide `amount` or `precise_amount` (at least one). */
+  amount?: number;
+  /** Amount after precision is applied. Provide `amount` or `precise_amount` (at least one). */
+  precise_amount?: number;
   precision: number;
   reference: string;
   description: string;
@@ -48,6 +51,8 @@ export type CreateTransactionResponse<T extends Record<string, unknown>> = {
 export type MultipleSourcesT = {
   identifier: string;
   distribution: Distribution;
+  /** Precise distribution amount (after precision). Used with `precise_amount` on the parent transaction. */
+  precise_distribution?: number;
   narration?: string;
 };
 

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -50,9 +50,18 @@ export type CreateTransactionResponse<T extends Record<string, unknown>> = {
 
 export type MultipleSourcesT = {
   identifier: string;
-  distribution: Distribution;
-  /** Precise distribution amount (after precision). Used with `precise_amount` on the parent transaction. */
-  precise_distribution?: number;
+  /**
+   * Percentage, fixed amount, or `left`. Required on a leg unless `precise_distribution`
+   * is set for an exact minor-unit value.
+   * see @link https://docs.blnkfinance.com/transactions/multiple-destinations#using-precise_distribution-with-precise_amount
+   */
+  distribution?: Distribution;
+  /**
+   * Fixed leg amount in minor units. Replaces `distribution` for exact values; the API
+   * accepts string values for large integers. Takes precedence over `distribution` when both
+   * are present on the same leg.
+   */
+  precise_distribution?: string | number;
   narration?: string;
 };
 

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -45,6 +45,34 @@ tap.test(`Creates a transaction`, async t => {
     childTest.end();
   });
 
+  t.test(
+    `Creates a transaction with precise_amount only (issue #42)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: CreateTransactions<meta_dataT> = {
+        precise_amount: 75000,
+        currency: `USD`,
+        description: `Precise amount transaction`,
+        meta_data: {company_name: `Test Company`},
+        precision: 100,
+        reference: `precise_ref_001`,
+        source: `@FundingPool`,
+        destination: `bln_recipient`,
+      };
+
+      const transaction = await transactions.create<meta_dataT>(data);
+      childTest.match(capturedRequest.args(), [[`transactions`, data, `POST`]]);
+      childTest.equal(transaction.status, 201);
+      childTest.end();
+    },
+  );
+
   t.test(`It should handle missing required fields`, async childTest => {
     const capturedRequest = childTest.captureFn(thirdPartyRequest);
     const transactions = new Transactions(

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -188,7 +188,7 @@ tap.test(`Issue #42 — split-transaction validator`, t => {
     tt => {
       const data: CreateTransactions<Record<string, never>> = {
         ...baseFields,
-        precise_amount: 189207535698279000,
+        precise_amount: `189207535698279000`,
         source: `bln_sarah`,
         destinations: [
           {
@@ -204,6 +204,67 @@ tap.test(`Issue #42 — split-transaction validator`, t => {
       tt.end();
     },
   );
+
+  t.test(
+    `validates precise_distribution strings beyond Number.MAX_SAFE_INTEGER exactly`,
+    tt => {
+      const legA = `9007199254740992`;
+      const legB = `1`;
+      const total = `9007199254740993`;
+
+      const valid: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        precise_amount: total,
+        source: `bln_sarah`,
+        destinations: [
+          {identifier: `bln_alice`, precise_distribution: legA},
+          {identifier: `bln_bob`, precise_distribution: legB},
+        ],
+      };
+
+      const invalid: CreateTransactions<Record<string, never>> = {
+        ...valid,
+        destinations: [
+          {identifier: `bln_alice`, precise_distribution: legA},
+          {identifier: `bln_bob`, precise_distribution: `2`},
+        ],
+      };
+
+      tt.equal(ValidateCreateTransactions(valid), null);
+      tt.ok(
+        ValidateCreateTransactions(invalid) !== null,
+        `sum must match exactly; Number() would mis-parse ${total}`,
+      );
+      tt.end();
+    },
+  );
+
+  t.test(`allows precise_amount as a string for large integers`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: `9007199254740993`,
+      source: `@FundingPool`,
+      destination: `bln_recipient`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid precise_amount string values`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: `12.5`,
+      source: `bln_a`,
+      destination: `bln_b`,
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `precise_amount must be a non-negative integer string or number.`,
+    );
+    tt.end();
+  });
 
   t.test(
     `rejects split legs missing both distribution and precise_distribution`,

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -1,0 +1,172 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateCreateTransactions} from "../../../../src/blnk/utils/validators/transactionValidators";
+import {CreateTransactions} from "../../../../src/types/transactions";
+
+const baseFields = {
+  precision: 100,
+  reference: `ref_split_001`,
+  description: `Split transaction`,
+  currency: `USD`,
+};
+
+tap.test(`Issue #42 — split-transaction validator`, t => {
+  t.test(`allows multiple sources with a single destination`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 30000,
+      sources: [
+        {identifier: `bln_alice`, distribution: `10%`},
+        {identifier: `bln_bob`, distribution: `20000`},
+        {identifier: `bln_charlie`, distribution: `left`},
+      ],
+      destination: `bln_sarah`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows a single source with multiple destinations`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 30000,
+      source: `bln_sarah`,
+      destinations: [
+        {identifier: `bln_alice`, distribution: `10%`},
+        {identifier: `bln_bob`, distribution: `20000`},
+        {identifier: `bln_charlie`, distribution: `left`},
+      ],
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects sources without destination`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 30000,
+      sources: [{identifier: `bln_alice`, distribution: `100%`}],
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `'destination' is required when using 'sources'.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects destinations without source`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 30000,
+      destinations: [{identifier: `bln_alice`, distribution: `100%`}],
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `'source' is required when using 'destinations'.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects sources with destinations array`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 30000,
+      sources: [{identifier: `bln_alice`, distribution: `100%`}],
+      destination: `bln_sarah`,
+      destinations: [{identifier: `bln_bob`, distribution: `left`}],
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Both 'destination' and 'destinations' cannot be provided together.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects sources combined with destinations routing`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 30000,
+      sources: [{identifier: `bln_alice`, distribution: `100%`}],
+      destinations: [{identifier: `bln_bob`, distribution: `100%`}],
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `'sources' requires a single 'destination'; use 'destination' instead of 'destinations'.`,
+    );
+    tt.end();
+  });
+
+  t.test(
+    `uses correct error message when destination and destinations are both set`,
+    tt => {
+      const data: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        amount: 1000,
+        source: `bln_source`,
+        destination: `bln_dest_a`,
+        destinations: [{identifier: `bln_dest_b`, distribution: `100%`}],
+      };
+
+      tt.equal(
+        ValidateCreateTransactions(data),
+        `Both 'destination' and 'destinations' cannot be provided together.`,
+      );
+      tt.not(
+        ValidateCreateTransactions(data),
+        `Both 'source' and 'sources' cannot be provided together.`,
+        `must not reuse the source/sources error message`,
+      );
+      tt.end();
+    },
+  );
+
+  t.test(`allows precise_amount-only payloads`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: 3000000,
+      source: `@FundingPool`,
+      destination: `bln_recipient`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows precise_amount-only with multiple sources split`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: 3000000,
+      sources: [
+        {identifier: `bln_alice`, distribution: `10%`},
+        {identifier: `bln_bob`, distribution: `2000000`},
+        {identifier: `bln_charlie`, distribution: `left`},
+      ],
+      destination: `bln_sarah`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects when neither amount nor precise_amount is provided`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      source: `bln_a`,
+      destination: `bln_b`,
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Either 'amount' or 'precise_amount' must be provided.`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -168,5 +168,113 @@ tap.test(`Issue #42 — split-transaction validator`, t => {
     tt.end();
   });
 
+  t.test(`allows split legs that use precise_distribution only`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: 10000,
+      source: `bln_sarah`,
+      destinations: [
+        {identifier: `bln_merchant`, precise_distribution: `9733`},
+        {identifier: `bln_fee`, precise_distribution: `267`},
+      ],
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(
+    `allows mixed precise_distribution and percentage distribution legs`,
+    tt => {
+      const data: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        precise_amount: 189207535698279000,
+        source: `bln_sarah`,
+        destinations: [
+          {
+            identifier: `bln_alice`,
+            precise_distribution: `37841507139655800`,
+          },
+          {identifier: `bln_bob`, distribution: `20%`},
+          {identifier: `bln_charlie`, distribution: `left`},
+        ],
+      };
+
+      tt.equal(ValidateCreateTransactions(data), null);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `rejects split legs missing both distribution and precise_distribution`,
+    tt => {
+      const data: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        amount: 1000,
+        source: `bln_sarah`,
+        destinations: [{identifier: `bln_alice`}],
+      };
+
+      tt.equal(
+        ValidateCreateTransactions(data),
+        `Each destination leg must include either 'distribution' or 'precise_distribution'.`,
+      );
+      tt.end();
+    },
+  );
+
+  t.test(`rejects invalid precise_distribution values`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: 1000,
+      source: `bln_sarah`,
+      destinations: [
+        {identifier: `bln_alice`, precise_distribution: `not-a-number`},
+      ],
+    };
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Invalid precise_distribution for leg: bln_alice.`,
+    );
+    tt.end();
+  });
+
+  t.test(
+    `uses amount for distribution math when both amount and precise_amount are provided`,
+    tt => {
+      const validWithAmount: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        amount: 10000,
+        precise_amount: 999999,
+        source: `bln_sarah`,
+        destinations: [
+          {identifier: `bln_merchant`, precise_distribution: `9733`},
+          {identifier: `bln_fee`, precise_distribution: `267`},
+        ],
+      };
+
+      const invalidIfPreciseAmountUsed: CreateTransactions<
+        Record<string, never>
+      > = {
+        ...baseFields,
+        amount: 10000,
+        precise_amount: 999999,
+        source: `bln_sarah`,
+        destinations: [
+          {identifier: `bln_merchant`, precise_distribution: `999998`},
+          {identifier: `bln_fee`, precise_distribution: `1`},
+        ],
+      };
+
+      tt.equal(ValidateCreateTransactions(validWithAmount), null);
+      tt.ok(
+        ValidateCreateTransactions(invalidIfPreciseAmountUsed) !== null,
+        `amount (10000) should take precedence over precise_amount (999999)`,
+      );
+      tt.end();
+    },
+  );
+
   t.end();
 });


### PR DESCRIPTION
## Summary
Fixes split-transaction validation for `Transactions.create` (#42):
- Enforces Blnk split-leg routing (`sources` → single `destination`; `source` → `destinations`)
- Fixes the `destination`/`destinations` error message (was incorrectly referencing source/sources)
- Allows `precise_amount`-only payloads when `amount` is omitted

Closes #42

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (139 pass)
- [x] `npm run lint`
- [x] Dedicated validator tests for each gap row in #42

Made with [Cursor](https://cursor.com)