### PR TITLE
feat(transactions): add Core create request fields (#40)

### DIFF
--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -8,6 +8,7 @@ import {
   UpdateTransactionStatus,
 } from "../../types/transactions";
 import {HandleError} from "../utils/logger";
+import {serializeCreateTransaction} from "../utils/transactionSerialization";
 import {
   ValidateBulkTransactions,
   ValidateCreateTransactions,
@@ -75,10 +76,12 @@ export class Transactions {
         return this.formatResponse(400, validatorResponse, null);
       }
 
+      const payload = serializeCreateTransaction(data);
+
       const response = await this.request<
         CreateTransactions<T>,
         CreateTransactionResponse<T>
-      >(`transactions`, data, `POST`);
+      >(`transactions`, payload, `POST`);
 
       if (response.data === null) {
         // Handle the error case
@@ -245,10 +248,15 @@ export class Transactions {
         return this.formatResponse(400, validatorResponse, null);
       }
 
+      const payload: BulkTransactions<T> = {
+        ...data,
+        transactions: data.transactions.map(serializeCreateTransaction),
+      };
+
       const response = await this.request<
         BulkTransactions<T>,
         BulkTransactionResponse<T>
-      >(`transactions/bulk`, data, `POST`);
+      >(`transactions/bulk`, payload, `POST`);
 
       if (response.data === null) {
         // Handle the error case

--- a/src/blnk/utils/transactionSerialization.ts
+++ b/src/blnk/utils/transactionSerialization.ts
@@ -1,0 +1,44 @@
+import {
+  CreateTransactions,
+  TransactionDateInput,
+} from "../../types/transactions";
+
+/**
+ * Serializes a transaction date field for the Blnk API (RFC3339 / ISO 8601 string).
+ */
+export function serializeTransactionDate(
+  value: TransactionDateInput | undefined,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value;
+}
+
+/**
+ * Prepares a create-transaction payload for the API, converting Date fields to ISO strings.
+ */
+export function serializeCreateTransaction<T extends Record<string, unknown>>(
+  data: CreateTransactions<T>,
+): CreateTransactions<T> {
+  return {
+    ...data,
+    inflight_expiry_date: serializeTransactionDate(
+      data.inflight_expiry_date,
+    ) as CreateTransactions<T>[`inflight_expiry_date`],
+    scheduled_for: serializeTransactionDate(
+      data.scheduled_for,
+    ) as CreateTransactions<T>[`scheduled_for`],
+    effective_date: serializeTransactionDate(
+      data.effective_date,
+    ) as CreateTransactions<T>[`effective_date`],
+    inflight_commit_date: serializeTransactionDate(
+      data.inflight_commit_date,
+    ) as CreateTransactions<T>[`inflight_commit_date`],
+  };
+}

--- a/src/blnk/utils/transactionSerialization.ts
+++ b/src/blnk/utils/transactionSerialization.ts
@@ -4,7 +4,34 @@ import {
 } from "../../types/transactions";
 
 /**
- * Serializes a transaction date field for the Blnk API (RFC3339 / ISO 8601 string).
+ * Matches Blnk Core `time.Parse("2006-01-02T15:04:05Z07:00", …)` — RFC3339 without fractional seconds.
+ */
+export const RFC3339_DATETIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/;
+
+export function isValidTransactionDateInput(
+  value: TransactionDateInput,
+): boolean {
+  if (value instanceof Date) {
+    return !isNaN(value.getTime());
+  }
+
+  if (typeof value === `string`) {
+    const trimmed = value.trim();
+    if (trimmed === ``) {
+      return false;
+    }
+    if (!RFC3339_DATETIME.test(trimmed)) {
+      return false;
+    }
+    return !isNaN(Date.parse(trimmed));
+  }
+
+  return false;
+}
+
+/**
+ * Serializes a transaction date field for the Blnk API (RFC3339 string).
  */
 export function serializeTransactionDate(
   value: TransactionDateInput | undefined,
@@ -14,7 +41,7 @@ export function serializeTransactionDate(
   }
 
   if (value instanceof Date) {
-    return value.toISOString();
+    return value.toISOString().replace(/\.\d{3}Z$/, `Z`);
   }
 
   return value;

--- a/src/blnk/utils/transactionSerialization.ts
+++ b/src/blnk/utils/transactionSerialization.ts
@@ -4,10 +4,11 @@ import {
 } from "../../types/transactions";
 
 /**
- * Matches Blnk Core `time.Parse("2006-01-02T15:04:05Z07:00", …)` — RFC3339 without fractional seconds.
+ * Matches Blnk Core `time.Parse("2006-01-02T15:04:05Z07:00", …)` in
+ * `api/model/model.go` — RFC3339 without fractional seconds.
  */
 export const RFC3339_DATETIME =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$/;
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}(?::\d{2}|\d{2}))$/;
 
 export function isValidTransactionDateInput(
   value: TransactionDateInput,

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -7,19 +7,10 @@ import {
   UpdateTransactionStatus,
 } from "../../../types/transactions";
 import {IsValidString} from "../stringUtils";
+import {isValidTransactionDateInput} from "../transactionSerialization";
 import {isValidMetaData} from "./ledgerBalance";
 
 const NON_NEGATIVE_INTEGER_STRING = /^\d+$/;
-
-function isValidDateInput(value: TransactionDateInput): boolean {
-  if (value instanceof Date) {
-    return !isNaN(value.getTime());
-  }
-  if (typeof value === `string` && value.trim() !== ``) {
-    return !isNaN(Date.parse(value));
-  }
-  return false;
-}
 
 function validateOptionalDateField(
   value: TransactionDateInput | undefined,
@@ -28,7 +19,7 @@ function validateOptionalDateField(
   if (value === undefined) {
     return null;
   }
-  if (!isValidDateInput(value)) {
+  if (!isValidTransactionDateInput(value)) {
     return `Invalid ${fieldName}.`;
   }
   return null;

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -3,12 +3,36 @@ import {
   BulkTransactions,
   CreateTransactions,
   MultipleSourcesT,
+  TransactionDateInput,
   UpdateTransactionStatus,
 } from "../../../types/transactions";
 import {IsValidString} from "../stringUtils";
 import {isValidMetaData} from "./ledgerBalance";
 
 const NON_NEGATIVE_INTEGER_STRING = /^\d+$/;
+
+function isValidDateInput(value: TransactionDateInput): boolean {
+  if (value instanceof Date) {
+    return !isNaN(value.getTime());
+  }
+  if (typeof value === `string` && value.trim() !== ``) {
+    return !isNaN(Date.parse(value));
+  }
+  return false;
+}
+
+function validateOptionalDateField(
+  value: TransactionDateInput | undefined,
+  fieldName: string,
+): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  if (!isValidDateInput(value)) {
+    return `Invalid ${fieldName}.`;
+  }
+  return null;
+}
 
 type TransactionTotal =
   | {arithmetic: `number`; value: number}
@@ -230,23 +254,40 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
     return `Inflight must be a boolean if provided.`;
   }
 
-  if (
-    data.inflight_expiry_date &&
-    !(
-      data.inflight_expiry_date instanceof Date &&
-      !isNaN(data.inflight_expiry_date.getTime())
-    )
-  ) {
-    return `Invalid inflight expiry date.`;
+  const inflightExpiryError = validateOptionalDateField(
+    data.inflight_expiry_date,
+    `inflight expiry date`,
+  );
+  if (inflightExpiryError) {
+    return inflightExpiryError;
   }
 
-  if (
-    data.scheduled_for &&
-    !(
-      data.scheduled_for instanceof Date && !isNaN(data.scheduled_for.getTime())
-    )
-  ) {
-    return `Invalid scheduled date.`;
+  const scheduledForError = validateOptionalDateField(
+    data.scheduled_for,
+    `scheduled date`,
+  );
+  if (scheduledForError) {
+    return scheduledForError;
+  }
+
+  const effectiveDateError = validateOptionalDateField(
+    data.effective_date,
+    `effective_date`,
+  );
+  if (effectiveDateError) {
+    return effectiveDateError;
+  }
+
+  const inflightCommitError = validateOptionalDateField(
+    data.inflight_commit_date,
+    `inflight_commit_date`,
+  );
+  if (inflightCommitError) {
+    return inflightCommitError;
+  }
+
+  if (data.skip_queue !== undefined && typeof data.skip_queue !== `boolean`) {
+    return `skip_queue must be a boolean if provided.`;
   }
 
   if (

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,4 +1,10 @@
-/** RFC3339 / ISO 8601 datetime accepted by the Blnk transactions API. */
+/**
+ * Transaction datetime input. Prefer a `Date` object so the SDK serializes it.
+ *
+ * String values must match Blnk Core `time.Parse("2006-01-02T15:04:05Z07:00")`
+ * (e.g. `2024-04-22T15:28:03+00:00` or `2025-02-15T10:30:00Z`). Date-only
+ * strings are rejected.
+ */
 export type TransactionDateInput = Date | string;
 
 export interface CreateTransactions<T extends Record<string, unknown>> {

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -1,7 +1,14 @@
+/** RFC3339 / ISO 8601 datetime accepted by the Blnk transactions API. */
+export type TransactionDateInput = Date | string;
+
 export interface CreateTransactions<T extends Record<string, unknown>> {
   /** Human-readable amount. Provide `amount` or `precise_amount` (at least one). */
   amount?: number;
-  /** Amount after precision is applied. Provide `amount` or `precise_amount` (at least one). */
+  /**
+   * Amount in minor units after `precision` is applied. Provide `amount` or
+   * `precise_amount` (at least one). Prefer strings for values larger than
+   * `Number.MAX_SAFE_INTEGER`.
+   */
   precise_amount?: number | string;
   precision: number;
   reference: string;
@@ -13,8 +20,18 @@ export interface CreateTransactions<T extends Record<string, unknown>> {
   destinations?: MultipleSourcesT[];
   destination?: string;
   inflight?: boolean;
-  inflight_expiry_date?: Date;
-  scheduled_for?: Date;
+  /** When `inflight` is true, void the transaction after this time. */
+  inflight_expiry_date?: TransactionDateInput;
+  /** When `inflight` is true, automatically commit at this time. */
+  inflight_commit_date?: TransactionDateInput;
+  scheduled_for?: TransactionDateInput;
+  /**
+   * Financial effective date for the transaction (ISO 8601). Defaults to
+   * `created_at` when omitted.
+   */
+  effective_date?: TransactionDateInput;
+  /** Process synchronously without queuing. Default: `false`. */
+  skip_queue?: boolean;
   allow_overdraft?: boolean;
   meta_data?: T;
 }
@@ -34,17 +51,25 @@ export type CreateTransactionResponse<T extends Record<string, unknown>> = {
   transaction_id: string;
   amount: number;
   precision: number;
-  precise_amount: number;
+  precise_amount: number | string;
   reference: string;
   description: string;
   rate: number;
   currency: string;
   status: StatusType;
+  hash?: string;
+  parent_transaction?: string;
   source?: string;
   destination?: string;
   sources?: MultipleSourcesT[];
   destinations?: MultipleSourcesT[];
-  created_at: Date;
+  skip_queue?: boolean;
+  inflight?: boolean;
+  created_at: Date | string;
+  scheduled_for?: Date | string;
+  inflight_expiry_date?: Date | string;
+  inflight_commit_date?: Date | string;
+  effective_date?: Date | string;
   meta_data?: T;
 };
 
@@ -58,8 +83,8 @@ export type MultipleSourcesT = {
   distribution?: Distribution;
   /**
    * Fixed leg amount in minor units. Replaces `distribution` for exact values; the API
-   * accepts string values for large integers. Takes precedence over `distribution` when both
-   * are present on the same leg.
+   * accepts string values for large integers. Prefer strings for values larger than
+   * `Number.MAX_SAFE_INTEGER`.
    */
   precise_distribution?: string | number;
   narration?: string;

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -73,6 +73,48 @@ tap.test(`Creates a transaction`, async t => {
     },
   );
 
+  t.test(
+    `Creates a transaction with #40 fields and serializes dates (issue #40)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const effectiveDate = new Date(`2025-02-15T10:30:00.000Z`);
+      const data: CreateTransactions<meta_dataT> = {
+        amount: 10000,
+        currency: `USD`,
+        description: `Backdated skip-queue transaction`,
+        meta_data: {company_name: `Test Company`},
+        precision: 100,
+        reference: `issue_40_ref_001`,
+        source: `@FundingPool`,
+        destination: `bln_recipient`,
+        skip_queue: true,
+        effective_date: effectiveDate,
+        inflight_commit_date: `2025-06-01T12:00:00Z`,
+      };
+
+      const transaction = await transactions.create<meta_dataT>(data);
+
+      childTest.match(capturedRequest.args(), [
+        [
+          `transactions`,
+          {
+            ...data,
+            effective_date: effectiveDate.toISOString(),
+          },
+          `POST`,
+        ],
+      ]);
+      childTest.equal(transaction.status, 201);
+      childTest.end();
+    },
+  );
+
   t.test(`It should handle missing required fields`, async childTest => {
     const capturedRequest = childTest.captureFn(thirdPartyRequest);
     const transactions = new Transactions(

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -105,7 +105,7 @@ tap.test(`Creates a transaction`, async t => {
           `transactions`,
           {
             ...data,
-            effective_date: effectiveDate.toISOString(),
+            effective_date: `2025-02-15T10:30:00Z`,
           },
           `POST`,
         ],
@@ -309,6 +309,72 @@ tap.test(`Creates bulk transactions`, async t => {
     childTest.equal(bulkResponse.status, 201);
     childTest.end();
   });
+
+  t.test(
+    `createBulk serializes date fields on each transaction (issue #40)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const effectiveDate = new Date(`2025-02-15T10:30:00.000Z`);
+      const scheduledDate = new Date(`2025-07-01T08:00:00.000Z`);
+      const data: BulkTransactions<meta_dataT> = {
+        transactions: [
+          {
+            amount: 1000,
+            currency: `USD`,
+            description: `Bulk txn with effective_date`,
+            meta_data: {department: `sales`, project: `Q4_campaign`},
+            precision: 100,
+            reference: `bulk_txn_date_001`,
+            source: `@source_account_1`,
+            destination: `@destination_account_1`,
+            effective_date: effectiveDate,
+            inflight_commit_date: `2025-06-01T12:00:00Z`,
+          },
+          {
+            amount: 2000,
+            currency: `USD`,
+            description: `Bulk txn with scheduled_for`,
+            meta_data: {department: `marketing`, project: `Q4_campaign`},
+            precision: 100,
+            reference: `bulk_txn_date_002`,
+            source: `@source_account_2`,
+            destination: `@destination_account_2`,
+            scheduled_for: scheduledDate,
+            skip_queue: true,
+          },
+        ],
+      };
+
+      const bulkResponse = await transactions.createBulk<meta_dataT>(data);
+
+      childTest.match(capturedRequest.args(), [
+        [
+          `transactions/bulk`,
+          {
+            transactions: [
+              {
+                ...data.transactions[0],
+                effective_date: `2025-02-15T10:30:00Z`,
+              },
+              {
+                ...data.transactions[1],
+                scheduled_for: `2025-07-01T08:00:00Z`,
+              },
+            ],
+          },
+          `POST`,
+        ],
+      ]);
+      childTest.equal(bulkResponse.status, 201);
+      childTest.end();
+    },
+  );
 
   t.test(
     `Creates basic bulk transactions without optional flags`,

--- a/tests/unit/blnk/utils/transactionSerialization.test.ts
+++ b/tests/unit/blnk/utils/transactionSerialization.test.ts
@@ -1,0 +1,64 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  serializeCreateTransaction,
+  serializeTransactionDate,
+} from "../../../../src/blnk/utils/transactionSerialization";
+import {CreateTransactions} from "../../../../src/types/transactions";
+
+tap.test(`Issue #40 — transaction serialization`, t => {
+  t.test(`serializes Date fields to ISO strings`, tt => {
+    const effectiveDate = new Date(`2025-02-15T10:30:00.000Z`);
+    const data: CreateTransactions<Record<string, never>> = {
+      amount: 1000,
+      precision: 100,
+      reference: `ref_001`,
+      description: `Backdated transaction`,
+      currency: `USD`,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      effective_date: effectiveDate,
+      inflight_commit_date: new Date(`2025-06-01T12:00:00.000Z`),
+      scheduled_for: new Date(`2025-07-01T08:00:00.000Z`),
+      inflight_expiry_date: new Date(`2025-08-01T08:00:00.000Z`),
+    };
+
+    const serialized = serializeCreateTransaction(data);
+
+    tt.equal(serialized.effective_date, effectiveDate.toISOString());
+    tt.equal(serialized.inflight_commit_date, `2025-06-01T12:00:00.000Z`);
+    tt.equal(serialized.scheduled_for, `2025-07-01T08:00:00.000Z`);
+    tt.equal(serialized.inflight_expiry_date, `2025-08-01T08:00:00.000Z`);
+    tt.end();
+  });
+
+  t.test(`passes through ISO date strings unchanged`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      amount: 1000,
+      precision: 100,
+      reference: `ref_002`,
+      description: `Backdated transaction`,
+      currency: `USD`,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      effective_date: `2025-02-15T10:30:00Z`,
+      inflight_commit_date: `2025-06-01T12:00:00Z`,
+    };
+
+    const serialized = serializeCreateTransaction(data);
+
+    tt.equal(serialized.effective_date, `2025-02-15T10:30:00Z`);
+    tt.equal(serialized.inflight_commit_date, `2025-06-01T12:00:00Z`);
+    tt.end();
+  });
+
+  t.test(
+    `serializeTransactionDate returns undefined for undefined input`,
+    tt => {
+      tt.equal(serializeTransactionDate(undefined), undefined);
+      tt.end();
+    },
+  );
+
+  t.end();
+});

--- a/tests/unit/blnk/utils/transactionSerialization.test.ts
+++ b/tests/unit/blnk/utils/transactionSerialization.test.ts
@@ -25,10 +25,10 @@ tap.test(`Issue #40 — transaction serialization`, t => {
 
     const serialized = serializeCreateTransaction(data);
 
-    tt.equal(serialized.effective_date, effectiveDate.toISOString());
-    tt.equal(serialized.inflight_commit_date, `2025-06-01T12:00:00.000Z`);
-    tt.equal(serialized.scheduled_for, `2025-07-01T08:00:00.000Z`);
-    tt.equal(serialized.inflight_expiry_date, `2025-08-01T08:00:00.000Z`);
+    tt.equal(serialized.effective_date, `2025-02-15T10:30:00Z`);
+    tt.equal(serialized.inflight_commit_date, `2025-06-01T12:00:00Z`);
+    tt.equal(serialized.scheduled_for, `2025-07-01T08:00:00Z`);
+    tt.equal(serialized.inflight_expiry_date, `2025-08-01T08:00:00Z`);
     tt.end();
   });
 

--- a/tests/unit/blnk/utils/transactionSerialization.test.ts
+++ b/tests/unit/blnk/utils/transactionSerialization.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
 import {
+  isValidTransactionDateInput,
   serializeCreateTransaction,
   serializeTransactionDate,
 } from "../../../../src/blnk/utils/transactionSerialization";
@@ -59,6 +60,22 @@ tap.test(`Issue #40 — transaction serialization`, t => {
       tt.end();
     },
   );
+
+  t.test(`accepts Core example datetime formats`, tt => {
+    tt.ok(
+      isValidTransactionDateInput(`2024-04-22T15:28:03+00:00`),
+      `Core model_test inflight_commit_date example`,
+    );
+    tt.ok(
+      isValidTransactionDateInput(`2024-04-22T15:28:03+0000`),
+      `Core time.Parse offset without colon`,
+    );
+    tt.not(
+      isValidTransactionDateInput(`2024-04-22T15:28:03.000Z`),
+      `fractional seconds rejected for string date fields`,
+    );
+    tt.end();
+  });
 
   t.end();
 });

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -339,3 +339,102 @@ tap.test(`Issue #42 — split-transaction validator`, t => {
 
   t.end();
 });
+
+tap.test(`Issue #40 — create transaction request fields`, t => {
+  t.test(`allows skip_queue on create payloads`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      skip_queue: true,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows effective_date as an ISO string`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      effective_date: `2025-02-15T10:30:00Z`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows inflight_commit_date as a Date`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      inflight: true,
+      inflight_commit_date: new Date(`2025-06-01T12:00:00.000Z`),
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid skip_queue values`, tt => {
+    const data = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      skip_queue: `true`,
+    } as unknown as CreateTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `skip_queue must be a boolean if provided.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid effective_date values`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      effective_date: `not-a-date`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), `Invalid effective_date.`);
+    tt.end();
+  });
+
+  t.test(`rejects invalid inflight_commit_date values`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      inflight_commit_date: `bad-date`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), `Invalid inflight_commit_date.`);
+    tt.end();
+  });
+
+  t.test(`allows scheduled_for as an ISO string`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      scheduled_for: `2025-12-31T23:59:59Z`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -367,6 +367,20 @@ tap.test(`Issue #40 — create transaction request fields`, t => {
     tt.end();
   });
 
+  t.test(`allows inflight_commit_date as Core example string`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      inflight: true,
+      inflight_commit_date: `2024-04-22T15:28:03+00:00`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
   t.test(`allows inflight_commit_date as a Date`, tt => {
     const data: CreateTransactions<Record<string, never>> = {
       ...baseFields,

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -381,6 +381,32 @@ tap.test(`Issue #40 — create transaction request fields`, t => {
     tt.end();
   });
 
+  t.test(`allows effective_date with a numeric timezone offset`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      effective_date: `2024-04-22T15:28:03+00:00`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects date-only effective_date strings`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      effective_date: `2025-02-15`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), `Invalid effective_date.`);
+    tt.end();
+  });
+
   t.test(`rejects invalid skip_queue values`, tt => {
     const data = {
       ...baseFields,
@@ -433,6 +459,19 @@ tap.test(`Issue #40 — create transaction request fields`, t => {
     };
 
     tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects date-only scheduled_for strings`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      scheduled_for: `2025-12-31`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), `Invalid scheduled date.`);
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Adds `skip_queue`, `effective_date`, and `inflight_commit_date` to `CreateTransactions` (builds on #42 for `precise_amount` / `precise_distribution`)
- Validates new fields and accepts ISO date strings for transaction date inputs
- Serializes `Date` fields to ISO strings before `Transactions.create` and `createBulk` API calls
- Extends `CreateTransactionResponse` with reference-aligned fields (`skip_queue`, date fields, `hash`, `parent_transaction`)

## Acceptance criteria (#40)
- [x] Types include listed fields (`precise_amount` / `precise_distribution` covered in #42)
- [x] Validators allow API-valid payloads
- [x] Serialization matches API (ISO strings for date fields)
- [x] Response types match reference (partial; full response parity tracked in #43)
- [x] Tests for each gap row

## Notes
- `atomic` on split create is out of scope (#5)
- Closes #40

## Test plan
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:unit` (168 pass)


Made with [Cursor](https://cursor.com)