### PR TITLE
feat(transactions): ISO date strings and Distribution type parity (#41)

### DIFF
--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -336,12 +336,57 @@ function validateSplitLegs(
   return validateDistributionLegsNumber(legs, total.value);
 }
 
+/**
+ * Fixed-amount split legs: non-negative integer or decimal strings only.
+ * Rejects exponent (`1e3`), hex (`0x10`), and whitespace-padded values.
+ */
+const FIXED_AMOUNT_DISTRIBUTION = /^(?:\d+|\d+\.\d+)$/;
+
+/** Percentage split legs such as `20%` or `33.33%`. */
+const PERCENTAGE_DISTRIBUTION = /^(?:\d+|\d+\.\d+)%$/;
+
+const DISTRIBUTION_SUM_EPSILON = 1e-9;
+
+function parsePercentageDistribution(distribution: string): number | null {
+  if (!PERCENTAGE_DISTRIBUTION.test(distribution)) {
+    return null;
+  }
+
+  const value = Number(distribution.slice(0, -1));
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    return null;
+  }
+
+  return value;
+}
+
+function parseFixedAmountDistribution(distribution: string): number | null {
+  if (distribution.trim() !== distribution) {
+    return null;
+  }
+
+  if (!FIXED_AMOUNT_DISTRIBUTION.test(distribution)) {
+    return null;
+  }
+
+  const value = Number(distribution);
+  if (!Number.isFinite(value) || value < 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function distributionTotalsApproximatelyEqual(
+  sum: number,
+  amount: number,
+): boolean {
+  return Math.abs(sum - amount) <= DISTRIBUTION_SUM_EPSILON;
+}
+
 function isFixedDecimalDistribution(distribution: string): boolean {
-  return (
-    !distribution.endsWith(`%`) &&
-    distribution !== `left` &&
-    distribution.includes(`.`)
-  );
+  const parsed = parseFixedAmountDistribution(distribution);
+  return parsed !== null && !Number.isInteger(parsed);
 }
 
 function validateDistributionLegsBigInt(
@@ -377,31 +422,22 @@ function validateDistributionLegsBigInt(
     }
 
     if (distribution.endsWith(`%`)) {
-      const percentageValue = parseFloat(distribution.slice(0, -1));
-      if (
-        isNaN(percentageValue) ||
-        percentageValue < 0 ||
-        percentageValue > 100
-      ) {
+      const percentageValue = parsePercentageDistribution(distribution);
+      if (percentageValue === null) {
         return `Invalid percentage value in leg: ${leg.identifier}.`;
       }
       sum += (total * BigInt(Math.trunc(percentageValue))) / BigInt(100);
-    } else if (!isNaN(Number(distribution))) {
-      const numericValue = parseFloat(distribution);
-      if (numericValue < 0 || !Number.isFinite(numericValue)) {
-        return `Invalid numeric value in leg: ${leg.identifier}.`;
-      }
-      if (!Number.isInteger(numericValue)) {
-        return `Invalid distribution type for leg: ${leg.identifier}.`;
-      }
-      sum += BigInt(numericValue);
     } else if (distribution === `left`) {
       if (hasLeft) {
         return `Multiple 'left' distribution types are not allowed.`;
       }
       hasLeft = true;
     } else {
-      return `Invalid distribution type for leg: ${leg.identifier}.`;
+      const fixedAmount = parseFixedAmountDistribution(distribution);
+      if (fixedAmount === null || !Number.isInteger(fixedAmount)) {
+        return `Invalid distribution type for leg: ${leg.identifier}.`;
+      }
+      sum += BigInt(fixedAmount);
     }
   }
 
@@ -450,37 +486,31 @@ function validateDistributionLegsWithDecimals(
     }
 
     if (distribution.endsWith(`%`)) {
-      const percentageValue = parseFloat(distribution.slice(0, -1));
-      if (
-        isNaN(percentageValue) ||
-        percentageValue < 0 ||
-        percentageValue > 100
-      ) {
+      const percentageValue = parsePercentageDistribution(distribution);
+      if (percentageValue === null) {
         return `Invalid percentage value in leg: ${leg.identifier}.`;
       }
       sum += (percentageValue / 100) * amount;
-    } else if (!isNaN(Number(distribution))) {
-      const numericValue = parseFloat(distribution);
-      if (numericValue < 0) {
-        return `Invalid numeric value in leg: ${leg.identifier}.`;
-      }
-      sum += numericValue;
     } else if (distribution === `left`) {
       if (hasLeft) {
         return `Multiple 'left' distribution types are not allowed.`;
       }
       hasLeft = true;
     } else {
-      return `Invalid distribution type for leg: ${leg.identifier}.`;
+      const fixedAmount = parseFixedAmountDistribution(distribution);
+      if (fixedAmount === null) {
+        return `Invalid distribution type for leg: ${leg.identifier}.`;
+      }
+      sum += fixedAmount;
     }
   }
 
   if (hasLeft) {
     const remaining = amount - sum;
-    if (remaining < 0) {
+    if (remaining < -DISTRIBUTION_SUM_EPSILON) {
       return `Total distribution exceeds the specified amount.`;
     }
-  } else if (sum !== amount) {
+  } else if (!distributionTotalsApproximatelyEqual(sum, amount)) {
     return `Total distribution sum (${sum}) does not equal the specified amount (${amount}).`;
   }
 

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -336,10 +336,28 @@ function validateSplitLegs(
   return validateDistributionLegsNumber(legs, total.value);
 }
 
+function isFixedDecimalDistribution(distribution: string): boolean {
+  return (
+    !distribution.endsWith(`%`) &&
+    distribution !== `left` &&
+    distribution.includes(`.`)
+  );
+}
+
 function validateDistributionLegsBigInt(
   legs: MultipleSourcesT[],
   total: bigint,
 ): string | null {
+  const hasDecimalFixed = legs.some(
+    leg =>
+      leg.distribution !== undefined &&
+      isFixedDecimalDistribution(leg.distribution),
+  );
+
+  if (hasDecimalFixed && total <= BigInt(Number.MAX_SAFE_INTEGER)) {
+    return validateDistributionLegsWithDecimals(legs, Number(total));
+  }
+
   let sum = BigInt(0);
   let hasLeft = false;
 
@@ -368,8 +386,15 @@ function validateDistributionLegsBigInt(
         return `Invalid percentage value in leg: ${leg.identifier}.`;
       }
       sum += (total * BigInt(Math.trunc(percentageValue))) / BigInt(100);
-    } else if (NON_NEGATIVE_INTEGER_STRING.test(distribution)) {
-      sum += BigInt(distribution);
+    } else if (!isNaN(Number(distribution))) {
+      const numericValue = parseFloat(distribution);
+      if (numericValue < 0 || !Number.isFinite(numericValue)) {
+        return `Invalid numeric value in leg: ${leg.identifier}.`;
+      }
+      if (!Number.isInteger(numericValue)) {
+        return `Invalid distribution type for leg: ${leg.identifier}.`;
+      }
+      sum += BigInt(numericValue);
     } else if (distribution === `left`) {
       if (hasLeft) {
         return `Multiple 'left' distribution types are not allowed.`;
@@ -396,10 +421,29 @@ function validateDistributionLegsNumber(
   legs: MultipleSourcesT[],
   amount: number,
 ): string | null {
+  return validateDistributionLegsWithDecimals(legs, amount);
+}
+
+function validateDistributionLegsWithDecimals(
+  legs: MultipleSourcesT[],
+  amount: number,
+): string | null {
   let sum = 0;
   let hasLeft = false;
 
   for (const leg of legs) {
+    if (hasPreciseDistribution(leg)) {
+      const preciseValue = parsePreciseInteger(leg.precise_distribution!);
+      if (preciseValue === null) {
+        return `Invalid precise_distribution for leg: ${leg.identifier}.`;
+      }
+      if (preciseValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+        return `Invalid precise_distribution for leg: ${leg.identifier}.`;
+      }
+      sum += Number(preciseValue);
+      continue;
+    }
+
     const distribution = leg.distribution;
     if (!distribution || !IsValidString(distribution)) {
       return `Invalid distribution type for leg: ${leg.identifier}.`;

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -389,17 +389,33 @@ function isFixedDecimalDistribution(distribution: string): boolean {
   return parsed !== null && !Number.isInteger(parsed);
 }
 
+function hasDecimalPercentageDistribution(distribution: string): boolean {
+  const parsed = parsePercentageDistribution(distribution);
+  return parsed !== null && !Number.isInteger(parsed);
+}
+
+function legUsesDecimalDistribution(leg: MultipleSourcesT): boolean {
+  if (leg.distribution === undefined) {
+    return false;
+  }
+
+  return (
+    isFixedDecimalDistribution(leg.distribution) ||
+    hasDecimalPercentageDistribution(leg.distribution)
+  );
+}
+
 function validateDistributionLegsBigInt(
   legs: MultipleSourcesT[],
   total: bigint,
 ): string | null {
-  const hasDecimalFixed = legs.some(
-    leg =>
-      leg.distribution !== undefined &&
-      isFixedDecimalDistribution(leg.distribution),
-  );
+  const hasDecimalDistribution = legs.some(legUsesDecimalDistribution);
 
-  if (hasDecimalFixed && total <= BigInt(Number.MAX_SAFE_INTEGER)) {
+  if (hasDecimalDistribution && total > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return `Decimal distribution values are not supported with precise amounts beyond Number.MAX_SAFE_INTEGER.`;
+  }
+
+  if (hasDecimalDistribution && total <= BigInt(Number.MAX_SAFE_INTEGER)) {
     return validateDistributionLegsWithDecimals(legs, Number(total));
   }
 
@@ -426,7 +442,7 @@ function validateDistributionLegsBigInt(
       if (percentageValue === null) {
         return `Invalid percentage value in leg: ${leg.identifier}.`;
       }
-      sum += (total * BigInt(Math.trunc(percentageValue))) / BigInt(100);
+      sum += (total * BigInt(percentageValue)) / BigInt(100);
     } else if (distribution === `left`) {
       if (hasLeft) {
         return `Multiple 'left' distribution types are not allowed.`;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -96,7 +96,25 @@ export type MultipleSourcesT = {
   narration?: string;
 };
 
-export type Distribution = `${number}%` | `${number}` | `left`;
+/** Percentage share of the transaction total, e.g. `"20%"`. */
+export type PercentageDistribution = `${number}%`;
+
+/** Remaining balance after other split legs. */
+export type LeftDistribution = `left`;
+
+/**
+ * Fixed amount in transaction amount units. Matches API `distribution` strings,
+ * including decimals such as `"240.23"`.
+ */
+export type FixedAmountDistribution =
+  | `${number}`
+  | `${number}.${number}`
+  | `${number}.${number}${number}`;
+
+export type Distribution =
+  | PercentageDistribution
+  | LeftDistribution
+  | FixedAmountDistribution;
 
 //we can only update transactions with COMMIT or VOID
 //create function called commit, that takes in a transaction id and commits it

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -104,7 +104,8 @@ export type LeftDistribution = `left`;
 
 /**
  * Fixed amount in transaction amount units. Matches API `distribution` strings,
- * including decimals such as `"240.23"`.
+ * including decimals such as `"240.23"`. Exponent (`1e3`) and hex (`0x10`)
+ * forms are rejected by the SDK validator.
  */
 export type FixedAmountDistribution =
   | `${number}`

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -74,6 +74,70 @@ tap.test(`Creates a transaction`, async t => {
   );
 
   t.test(
+    `Creates a transaction with ISO date strings unchanged (issue #41)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: CreateTransactions<meta_dataT> = {
+        amount: 10000,
+        currency: `USD`,
+        description: `Scheduled inflight transaction`,
+        meta_data: {company_name: `Test Company`},
+        precision: 100,
+        reference: `issue_41_ref_001`,
+        source: `@FundingPool`,
+        destination: `bln_recipient`,
+        inflight: true,
+        scheduled_for: `2025-12-31T23:59:59Z`,
+        inflight_expiry_date: `2025-08-01T08:00:00Z`,
+      };
+
+      const transaction = await transactions.create<meta_dataT>(data);
+
+      childTest.match(capturedRequest.args(), [[`transactions`, data, `POST`]]);
+      childTest.equal(transaction.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `Creates a transaction with decimal distribution split (issue #41)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: CreateTransactions<meta_dataT> = {
+        amount: 1000,
+        currency: `USD`,
+        description: `Decimal distribution split`,
+        meta_data: {company_name: `Test Company`},
+        precision: 100,
+        reference: `issue_41_ref_002`,
+        source: `@FundingPool`,
+        destinations: [
+          {identifier: `bln_fee`, distribution: `240.23`},
+          {identifier: `bln_recipient`, distribution: `left`},
+        ],
+      };
+
+      const transaction = await transactions.create<meta_dataT>(data);
+
+      childTest.match(capturedRequest.args(), [[`transactions`, data, `POST`]]);
+      childTest.equal(transaction.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(
     `Creates a transaction with #40 fields and serializes dates (issue #40)`,
     async childTest => {
       const capturedRequest = childTest.captureFn(thirdPartyRequest);

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -554,5 +554,110 @@ tap.test(`Issue #41 — ISO date strings and Distribution parity`, t => {
     },
   );
 
+  t.test(`allows exact decimal sum without left`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `240.23`},
+        {identifier: `bln_recipient`, distribution: `759.77`},
+      ],
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects scientific notation distribution strings`, tt => {
+    const data = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `1e3`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+    } as unknown as CreateTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Invalid distribution type for leg: bln_fee.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects hex distribution strings`, tt => {
+    const data = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `0x10`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+    } as unknown as CreateTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Invalid distribution type for leg: bln_fee.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects whitespace-padded distribution strings`, tt => {
+    const data = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: ` 240.23 `},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+    } as unknown as CreateTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Invalid distribution type for leg: bln_fee.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects Infinity distribution strings`, tt => {
+    const data = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `Infinity`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+    } as unknown as CreateTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Invalid distribution type for leg: bln_fee.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects malformed decimal distribution strings`, tt => {
+    const data = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `240.23.1`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+    } as unknown as CreateTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `Invalid distribution type for leg: bln_fee.`,
+    );
+    tt.end();
+  });
+
   t.end();
 });

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -659,5 +659,60 @@ tap.test(`Issue #41 — ISO date strings and Distribution parity`, t => {
     tt.end();
   });
 
+  t.test(`allows decimal percentage distributions with precise_amount`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      precise_amount: 30000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_a`, distribution: `33.33%`},
+        {identifier: `bln_b`, distribution: `66.67%`},
+      ],
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(
+    `allows decimal percentage with left under precise_distribution split`,
+    tt => {
+      const data: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        amount: 30000,
+        source: `@FundingPool`,
+        destinations: [
+          {identifier: `bln_a`, distribution: `33.33%`},
+          {identifier: `bln_b`, precise_distribution: `5000`},
+          {identifier: `bln_c`, distribution: `left`},
+        ],
+      };
+
+      tt.equal(ValidateCreateTransactions(data), null);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `rejects decimal distributions with precise_amount beyond MAX_SAFE_INTEGER`,
+    tt => {
+      const data: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        precise_amount: `9007199254740993`,
+        source: `@FundingPool`,
+        destinations: [
+          {identifier: `bln_a`, distribution: `33.33%`},
+          {identifier: `bln_b`, distribution: `left`},
+        ],
+      };
+
+      tt.equal(
+        ValidateCreateTransactions(data),
+        `Decimal distribution values are not supported with precise amounts beyond Number.MAX_SAFE_INTEGER.`,
+      );
+      tt.end();
+    },
+  );
+
   t.end();
 });

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -491,3 +491,68 @@ tap.test(`Issue #40 — create transaction request fields`, t => {
 
   t.end();
 });
+
+tap.test(`Issue #41 — ISO date strings and Distribution parity`, t => {
+  t.test(`allows scheduled_for as an ISO string on create`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      scheduled_for: `2025-07-01T08:00:00Z`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows inflight_expiry_date as an ISO string on create`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      inflight: true,
+      inflight_expiry_date: `2025-08-01T08:00:00Z`,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows decimal fixed distribution strings such as 240.23`, tt => {
+    const data: CreateTransactions<Record<string, never>> = {
+      ...baseFields,
+      amount: 1000,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `240.23`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(
+    `allows decimal distribution when precise_distribution is on another leg`,
+    tt => {
+      const data: CreateTransactions<Record<string, never>> = {
+        ...baseFields,
+        amount: 1000,
+        source: `@FundingPool`,
+        destinations: [
+          {identifier: `bln_fee`, distribution: `240.23`},
+          {identifier: `bln_recipient`, precise_distribution: `500`},
+          {identifier: `bln_treasury`, distribution: `left`},
+        ],
+      };
+
+      tt.equal(ValidateCreateTransactions(data), null);
+      tt.end();
+    },
+  );
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Widens `Distribution` to explicitly accept decimal fixed amounts (e.g. `"240.23"`), matching Blnk Core `parseFixedAmount` behavior
- Validates decimal split legs alongside `precise_distribution` on other legs
- Adds endpoint and validator tests for `scheduled_for` / `inflight_expiry_date` ISO strings and decimal distribution splits

## Acceptance criteria (#41)
- [x] Types include listed fields (`TransactionDateInput` for date fields from #40; expanded `Distribution` union)
- [x] Validators allow API-valid payloads (decimal distributions, ISO date strings)
- [x] Serialization matches API (ISO strings pass through unchanged; `Date` serialized via #40 helper)
- [x] Response types match reference (`scheduled_for` / `inflight_expiry_date` as `Date | string`)
- [x] Tests for each gap row

## Core reference
- `blnk/model/transaction.go` — `Distribution` is `string`; `parseFixedAmount` uses `strconv.ParseFloat` for fixed amounts
- `blnk/api/model/model.go` — `scheduled_for` / `inflight_expiry_date` validated as RFC3339 strings

## Test plan
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:unit` (189 pass)

Closes #41

Made with [Cursor](https://cursor.com)