### PR TITLE
feat(transactions): align CreateTransactionResponse with Core API (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,36 @@ const newTransaction = await Transactions.create({
 console.log("Transaction Recorded:", newTransaction);
 ```
 
+### Create transaction response
+
+`Transactions.create` resolves to a `CreateTransactionResponse` that matches the Core API reference, including `hash`, `parent_transaction`, `allow_overdraft`, and inflight date fields (`scheduled_for`, `inflight_expiry_date`, `inflight_commit_date`):
+
+```typescript
+interface CreateTransactionResponse<T extends Record<string, unknown>> {
+  transaction_id: string;
+  amount: number;
+  precision: number;
+  precise_amount: number | string;
+  reference: string;
+  description: string;
+  rate: number;
+  currency: string;
+  status: StatusType;
+  hash: string;
+  parent_transaction: string; // empty string when none
+  allow_overdraft: boolean;
+  inflight: boolean;
+  created_at: Date | string;
+  scheduled_for: Date | string;
+  inflight_expiry_date: Date | string;
+  inflight_commit_date: Date | string;
+  effective_date?: Date | string;
+  source?: string;
+  destination?: string;
+  meta_data?: T;
+}
+```
+
 ---
 
 ## 7. Bulk Transactions

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -53,6 +53,12 @@ export type PryTransactionStatus =
 export type InflightStatus = `commit` | `void`;
 export type StatusType = PryTransactionStatus;
 
+/**
+ * Response from `POST /transactions` and related transaction mutations.
+ * Field shapes follow the Blnk Core create-transaction reference.
+ *
+ * @see https://docs.blnkfinance.com/reference/create-transaction
+ */
 export type CreateTransactionResponse<T extends Record<string, unknown>> = {
   transaction_id: string;
   amount: number;
@@ -63,18 +69,24 @@ export type CreateTransactionResponse<T extends Record<string, unknown>> = {
   rate: number;
   currency: string;
   status: StatusType;
-  hash?: string;
-  parent_transaction?: string;
+  /** SHA-256 hash of the transaction details. */
+  hash: string;
+  /** Parent transaction ID, or empty string when none. */
+  parent_transaction: string;
   source?: string;
   destination?: string;
   sources?: MultipleSourcesT[];
   destinations?: MultipleSourcesT[];
+  allow_overdraft: boolean;
   skip_queue?: boolean;
-  inflight?: boolean;
+  inflight: boolean;
+  /** When true, all split legs succeed or fail together. */
+  atomic?: boolean;
+  overdraft_limit?: number;
   created_at: Date | string;
-  scheduled_for?: Date | string;
-  inflight_expiry_date?: Date | string;
-  inflight_commit_date?: Date | string;
+  scheduled_for: Date | string;
+  inflight_expiry_date: Date | string;
+  inflight_commit_date: Date | string;
   effective_date?: Date | string;
   meta_data?: T;
 };

--- a/tests/fixtures/coreCreateTransactionResponse.ts
+++ b/tests/fixtures/coreCreateTransactionResponse.ts
@@ -1,0 +1,29 @@
+import {CreateTransactionResponse} from "../../src/types/transactions";
+
+/**
+ * Sample `POST /transactions` response from the Blnk Core API reference.
+ * @see https://docs.blnkfinance.com/reference/create-transaction
+ */
+export const coreCreateTransactionReferenceResponse: CreateTransactionResponse<
+  Record<string, never>
+> = {
+  amount: 1250.34,
+  rate: 0,
+  precision: 100,
+  precise_amount: 125034,
+  transaction_id: `txn_c4e70eb8-e4d6-4e04-a2e2-92a43b969e0c`,
+  parent_transaction: ``,
+  source: `bln_f344b673-e855-4bda-b769-3e94a02c1941`,
+  destination: `bln_d5cbde84-d20a-485b-8ce8-6677d782c3a1`,
+  reference: `ref_2ye281ewiu-1e17-dh17-eh18728hd245`,
+  currency: `USD`,
+  description: `Card payment on Stripe`,
+  status: `QUEUED`,
+  hash: `0b9c25fb5b00d6c71cb4ca87026bf6dc316e63353d3330deb588bd0b3d74dcc0`,
+  allow_overdraft: false,
+  inflight: false,
+  created_at: `2024-11-26T09:33:35.265582042Z`,
+  scheduled_for: `0001-01-01T00:00:00Z`,
+  inflight_expiry_date: `0001-01-01T00:00:00Z`,
+  inflight_commit_date: `0001-01-01T00:00:00Z`,
+};

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -1,0 +1,325 @@
+/* eslint-disable n/no-unpublished-import */
+/**
+ * Integration tests for SDK changes in issues #40–#43.
+ * Requires Blnk Core at http://localhost:5001 (docker compose up in blnk/).
+ *
+ * Run: npm run test:integration
+ */
+import tap from "tap";
+import {BlnkInit} from "../../src";
+import {BlnkClientOptions} from "../../src/types/blnkClient";
+import {CreateLedger} from "../../src/types/ledger";
+import {CreateLedgerBalance} from "../../src/types/ledgerBalances";
+import {
+  BulkTransactions,
+  CreateTransactions,
+} from "../../src/types/transactions";
+import {BASE_URL, GenerateRandomNumbersWithPrefix, Sleep} from "../utils.test";
+
+const clientOptions: BlnkClientOptions = {baseUrl: BASE_URL};
+const client = BlnkInit(``, clientOptions);
+
+const baseTxn = {
+  precision: 100,
+  currency: `USD`,
+  description: `SDK integration test`,
+  allow_overdraft: true,
+};
+
+async function createLedger(name: string) {
+  const response = await client.Ledgers.create({name} as CreateLedger<{}>);
+  tap.ok(response.status === 201, `ledger create ${name}: ${response.status}`);
+  return response.data!.ledger_id;
+}
+
+async function createBalance(ledgerId: string) {
+  const response = await client.LedgerBalances.create({
+    currency: `USD`,
+    ledger_id: ledgerId,
+    meta_data: {},
+  } as CreateLedgerBalance<{}>);
+  tap.ok(response.status === 201, `balance create: ${response.status}`);
+  return response.data!.balance_id;
+}
+
+tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
+  // Issue #40 — Transactions.create with new Core fields
+  t.test(`#40 skip_queue + effective_date`, async tt => {
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 1000,
+      reference: GenerateRandomNumbersWithPrefix(`issue40-skip`, 6),
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      skip_queue: true,
+      effective_date: `2025-02-15T10:30:00Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.equal(response.data?.skip_queue, true);
+    tt.equal(response.data?.effective_date, `2025-02-15T10:30:00Z`);
+    tt.end();
+  });
+
+  t.test(`#40 inflight_commit_date + scheduled_for`, async tt => {
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 1000,
+      reference: GenerateRandomNumbersWithPrefix(`issue40-dates`, 6),
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      inflight: true,
+      inflight_expiry_date: `2026-12-31T23:59:59Z`,
+      inflight_commit_date: `2024-04-22T15:28:03+00:00`,
+      scheduled_for: `2025-12-31T23:59:59Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.test(`#40 Transactions.createBulk serializes date fields`, async tt => {
+    const response = await client.Transactions.createBulk({
+      transactions: [
+        {
+          ...baseTxn,
+          amount: 500,
+          reference: GenerateRandomNumbersWithPrefix(`issue40-bulk-1`, 6),
+          source: `@FundingPool`,
+          destination: `@Recipient`,
+          effective_date: `2025-02-15T10:30:00Z`,
+          inflight_commit_date: `2025-06-01T12:00:00Z`,
+        },
+        {
+          ...baseTxn,
+          amount: 750,
+          reference: GenerateRandomNumbersWithPrefix(`issue40-bulk-2`, 6),
+          source: `@FundingPool`,
+          destination: `@Recipient`,
+          scheduled_for: `2025-07-01T08:00:00Z`,
+        },
+      ],
+    } as BulkTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    const bulk = response.data as {
+      transaction_count?: number;
+      batch_id?: string;
+      status?: string;
+    };
+    tt.equal(bulk?.transaction_count, 2, `Core accepted 2 bulk transactions`);
+    tt.ok(bulk?.batch_id, `batch_id returned from Core`);
+    tt.end();
+  });
+
+  // Issue #41 — ISO date strings + decimal distribution parity
+  t.test(`#41 decimal distribution (240.23) + ISO dates`, async tt => {
+    const ledgerId = await createLedger(`Issue41 Ledger`);
+    const destA = await createBalance(ledgerId);
+    const destB = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 1000,
+      reference: GenerateRandomNumbersWithPrefix(`issue41`, 6),
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: destA, distribution: `240.23`},
+        {identifier: destB, distribution: `left`},
+      ],
+      effective_date: `2024-04-22T15:28:03+00:00`,
+      inflight_expiry_date: `2025-08-01T08:00:00Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  // Issue #42 — split-transaction validator parity
+  t.test(`#42 multiple sources → single destination`, async tt => {
+    const ledgerId = await createLedger(`Issue42 Sources`);
+    const alice = await createBalance(ledgerId);
+    const bob = await createBalance(ledgerId);
+    const sarah = await createBalance(ledgerId);
+    const destination = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 30000,
+      reference: GenerateRandomNumbersWithPrefix(`issue42-src`, 6),
+      sources: [
+        {identifier: alice, distribution: `10%`},
+        {identifier: bob, distribution: `20000`},
+        {identifier: sarah, distribution: `left`},
+      ],
+      destination,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.test(`#42 single source → multiple destinations`, async tt => {
+    const ledgerId = await createLedger(`Issue42 Dests`);
+    const alice = await createBalance(ledgerId);
+    const bob = await createBalance(ledgerId);
+    const charlie = await createBalance(ledgerId);
+    const source = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 30000,
+      reference: GenerateRandomNumbersWithPrefix(`issue42-dest`, 6),
+      source,
+      destinations: [
+        {identifier: alice, distribution: `10%`},
+        {identifier: bob, distribution: `20000`},
+        {identifier: charlie, distribution: `left`},
+      ],
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.test(`#42 precise_distribution legs`, async tt => {
+    const ledgerId = await createLedger(`Issue42 Precise`);
+    const merchant = await createBalance(ledgerId);
+    const fee = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 10000,
+      reference: GenerateRandomNumbersWithPrefix(`issue42-precise`, 6),
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: merchant, precise_distribution: `9733`},
+        {identifier: fee, precise_distribution: `267`},
+      ],
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.test(`#42 precise_amount-only create`, async tt => {
+    const ledgerId = await createLedger(`Issue42 PreciseAmt`);
+    const destination = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      precise_amount: 75000,
+      reference: GenerateRandomNumbersWithPrefix(`issue42-pamt`, 6),
+      source: `@FundingPool`,
+      destination,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.test(`#42 Transactions.updateStatus commit`, async tt => {
+    const ledgerId = await createLedger(`Issue42 Inflight`);
+    const destination = await createBalance(ledgerId);
+
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 5000,
+      reference: GenerateRandomNumbersWithPrefix(`issue42-inflight`, 6),
+      source: `@FundingPool`,
+      destination,
+      inflight: true,
+      inflight_expiry_date: `2026-12-31T23:59:59Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    await Sleep(2);
+
+    const commitResp = await client.Transactions.updateStatus(
+      createResp.data!.transaction_id,
+      {status: `commit`},
+    );
+    tt.equal(commitResp.status, 200);
+    tt.end();
+  });
+
+  // Issue #43 — CreateTransactionResponse parity (hash, parent_transaction, inflight)
+  t.test(`#43 create response includes hash, parent_transaction, inflight`, async tt => {
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 1000,
+      reference: GenerateRandomNumbersWithPrefix(`issue43-resp`, 6),
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+      allow_overdraft: false,
+      inflight: false,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.hash, `hash present`);
+    tt.equal(response.data?.hash?.length, 64, `hash is SHA-256 hex`);
+    tt.type(response.data?.parent_transaction, `string`);
+    tt.equal(response.data?.inflight, false);
+    tt.type(response.data?.allow_overdraft, `boolean`);
+    tt.equal(response.data?.scheduled_for, `0001-01-01T00:00:00Z`);
+    tt.equal(response.data?.inflight_expiry_date, `0001-01-01T00:00:00Z`);
+  // Core omits inflight_commit_date when inflight is false
+    if (response.data?.inflight_commit_date !== undefined) {
+      tt.type(response.data.inflight_commit_date, `string`);
+    }
+    tt.end();
+  });
+
+  // Issue #43 — decimal percentage distributions with precise_amount
+  t.test(`#43 decimal percentage split (33.33% / 66.67%)`, async tt => {
+    const ledgerId = await createLedger(`Issue43 Ledger`);
+    const destA = await createBalance(ledgerId);
+    const destB = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      precise_amount: 30000,
+      reference: GenerateRandomNumbersWithPrefix(`issue43`, 6),
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: destA, distribution: `33.33%`},
+        {identifier: destB, distribution: `66.67%`},
+      ],
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.test(`#43 mixed decimal % + precise_distribution + left`, async tt => {
+    const ledgerId = await createLedger(`Issue43 Mixed`);
+    const a = await createBalance(ledgerId);
+    const b = await createBalance(ledgerId);
+    const c = await createBalance(ledgerId);
+
+    const response = await client.Transactions.create({
+      ...baseTxn,
+      amount: 30000,
+      reference: GenerateRandomNumbersWithPrefix(`issue43-mix`, 6),
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: a, distribution: `33.33%`},
+        {identifier: b, precise_distribution: `5000`},
+        {identifier: c, distribution: `left`},
+      ],
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(response.status, 201);
+    tt.ok(response.data?.transaction_id);
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/mocks/mockTransactions.ts
+++ b/tests/mocks/mockTransactions.ts
@@ -91,6 +91,8 @@ export function createDummyTransactionResponse<
     description: `Sample transaction description`,
     currency: `USD` as Currency,
     status: `INFLIGHT` as StatusType,
+    hash: `0b9c25fb5b00d6c71cb4ca87026bf6dc316e63353d3330deb588bd0b3d74dcc0`,
+    parent_transaction: ``,
     source: `source_12345`,
     destination: `destination_67890`,
     sources: [
@@ -99,7 +101,14 @@ export function createDummyTransactionResponse<
         distribution: `left`,
       },
     ] as MultipleSourcesT[],
+    allow_overdraft: false,
+    inflight: true,
+    skip_queue: false,
+    atomic: false,
     created_at: new Date(),
+    scheduled_for: `0001-01-01T00:00:00Z`,
+    inflight_expiry_date: `0001-01-01T00:00:00Z`,
+    inflight_commit_date: `0001-01-01T00:00:00Z`,
     meta_data: {} as T,
   };
 }

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -7,8 +7,10 @@ import {
 } from "../../../mocks/blnkClientMocks";
 import {BlnkRequest} from "../../../../src/types/general";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {coreCreateTransactionReferenceResponse} from "../../../fixtures/coreCreateTransactionResponse";
 import {
   BulkTransactions,
+  CreateTransactionResponse,
   CreateTransactions,
   UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
@@ -133,6 +135,79 @@ tap.test(`Creates a transaction`, async t => {
 
       childTest.match(capturedRequest.args(), [[`transactions`, data, `POST`]]);
       childTest.equal(transaction.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(`returns Core create response fields (issue #43)`, async childTest => {
+    const coreResponse = coreCreateTransactionReferenceResponse;
+    const responseReturningRequest: BlnkRequest = async () => ({
+      status: 201,
+      message: `Success`,
+      data: coreResponse,
+    });
+
+    const transactions = new Transactions(
+      responseReturningRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const data: CreateTransactions<meta_dataT> = {
+      amount: 1250.34,
+      currency: `USD`,
+      description: `Card payment on Stripe`,
+      meta_data: {company_name: `Test Company`},
+      precision: 100,
+      reference: `ref_2ye281ewiu-1e17-dh17-eh18728hd245`,
+      source: `@WorldUSD`,
+      destination: `@MyBalance`,
+      allow_overdraft: false,
+      inflight: false,
+    };
+
+    const transaction = await transactions.create<meta_dataT>(data);
+
+    childTest.equal(transaction.status, 201);
+    childTest.equal(transaction.data?.hash, coreResponse.hash);
+    childTest.equal(
+      transaction.data?.parent_transaction,
+      coreResponse.parent_transaction,
+    );
+    childTest.equal(
+      transaction.data?.allow_overdraft,
+      coreResponse.allow_overdraft,
+    );
+    childTest.equal(transaction.data?.inflight, coreResponse.inflight);
+    childTest.equal(
+      transaction.data?.scheduled_for,
+      coreResponse.scheduled_for,
+    );
+    childTest.equal(
+      transaction.data?.inflight_expiry_date,
+      coreResponse.inflight_expiry_date,
+    );
+    childTest.equal(
+      transaction.data?.inflight_commit_date,
+      coreResponse.inflight_commit_date,
+    );
+    childTest.end();
+  });
+
+  t.test(
+    `CreateTransactionResponse type includes gap fields (issue #43)`,
+    async childTest => {
+      const sample: CreateTransactionResponse<meta_dataT> = {
+        ...coreCreateTransactionReferenceResponse,
+        meta_data: {company_name: `Test Company`},
+      };
+
+      childTest.ok(sample.hash);
+      childTest.type(sample.parent_transaction, `string`);
+      childTest.type(sample.allow_overdraft, `boolean`);
+      childTest.ok(sample.inflight_expiry_date);
+      childTest.ok(sample.inflight_commit_date);
+      childTest.ok(sample.scheduled_for);
       childTest.end();
     },
   );

--- a/tests/unit/types/createTransactionResponse.test.ts
+++ b/tests/unit/types/createTransactionResponse.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {coreCreateTransactionReferenceResponse} from "../../fixtures/coreCreateTransactionResponse";
+import {CreateTransactionResponse} from "../../../src/types/transactions";
+
+tap.test(`Issue #43 — CreateTransactionResponse API parity`, t => {
+  t.test(`accepts Core API reference create response`, tt => {
+    const response: CreateTransactionResponse<Record<string, never>> =
+      coreCreateTransactionReferenceResponse;
+
+    tt.equal(response.hash.length, 64);
+    tt.equal(response.parent_transaction, ``);
+    tt.equal(response.allow_overdraft, false);
+    tt.equal(response.inflight, false);
+    tt.equal(response.scheduled_for, `0001-01-01T00:00:00Z`);
+    tt.equal(response.inflight_expiry_date, `0001-01-01T00:00:00Z`);
+    tt.equal(response.inflight_commit_date, `0001-01-01T00:00:00Z`);
+    tt.end();
+  });
+
+  t.test(`hash field is present on reference response`, tt => {
+    tt.ok(coreCreateTransactionReferenceResponse.hash);
+    tt.end();
+  });
+
+  t.test(`parent_transaction field is present on reference response`, tt => {
+    tt.type(
+      coreCreateTransactionReferenceResponse.parent_transaction,
+      `string`,
+    );
+    tt.end();
+  });
+
+  t.test(`allow_overdraft field is present on reference response`, tt => {
+    tt.type(coreCreateTransactionReferenceResponse.allow_overdraft, `boolean`);
+    tt.end();
+  });
+
+  t.test(`inflight date fields use ISO strings on reference response`, tt => {
+    tt.equal(
+      coreCreateTransactionReferenceResponse.inflight_expiry_date,
+      `0001-01-01T00:00:00Z`,
+    );
+    tt.equal(
+      coreCreateTransactionReferenceResponse.inflight_commit_date,
+      `0001-01-01T00:00:00Z`,
+    );
+    tt.equal(
+      coreCreateTransactionReferenceResponse.scheduled_for,
+      `0001-01-01T00:00:00Z`,
+    );
+    tt.end();
+  });
+
+  t.test(`accepts inflight create response with custom dates`, tt => {
+    const inflightResponse: CreateTransactionResponse<Record<string, never>> = {
+      ...coreCreateTransactionReferenceResponse,
+      status: `INFLIGHT`,
+      inflight: true,
+      inflight_expiry_date: `2026-12-31T23:59:59Z`,
+      inflight_commit_date: `2024-04-22T15:28:03+00:00`,
+      scheduled_for: `2025-12-31T23:59:59Z`,
+      effective_date: `2025-02-15T10:30:00Z`,
+      allow_overdraft: true,
+    };
+
+    tt.equal(inflightResponse.inflight_expiry_date, `2026-12-31T23:59:59Z`);
+    tt.equal(
+      inflightResponse.inflight_commit_date,
+      `2024-04-22T15:28:03+00:00`,
+    );
+    tt.equal(inflightResponse.allow_overdraft, true);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Align `CreateTransactionResponse` with Core create-transaction fields (status, inflight dates, and related response shape).
- Add Core reference fixture plus unit and integration coverage for issue #43.

Closes #43

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001)