### PR TITLE
feat(transactions): align BulkTransactionResponse with Core API (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ interface BulkTransactions<T extends Record<string, unknown>> {
   atomic?: boolean;        // Optional: All transactions succeed or fail together
   inflight?: boolean;      // Optional: Create transactions as inflight
   run_async?: boolean;     // Optional: Process transactions asynchronously
+  skip_queue?: boolean;    // Optional: Process without queuing
   transactions: CreateTransactions<T>[]; // Required: Array of transaction objects
 }
 ```
@@ -335,18 +336,22 @@ const asyncBulkData = {
 const asyncResponse = await Transactions.createBulk(asyncBulkData);
 ```
 
-### Response Format
+### Bulk transaction response
+
+`Transactions.createBulk` resolves to a `BulkTransactionResponse` that matches the Core API reference (`batch_id`, `status`, `transaction_count`, and optional `message` for async batches):
 
 ```typescript
-interface BulkTransactionResponse<T extends Record<string, unknown>> {
-  id: string;                                    // Bulk transaction ID
-  atomic: boolean;                               // Whether transactions were atomic
-  inflight: boolean;                             // Whether transactions were created as inflight
-  run_async: boolean;                            // Whether processing was asynchronous
-  transactions: CreateTransactionResponse<T>[];  // Array of individual transaction responses
-  created_at: Date;                              // Creation timestamp
+interface BulkTransactionResponse {
+  batch_id: string;
+  status: 'applied' | 'inflight' | 'queued' | string;
+  transaction_count?: number; // present on synchronous success
+  message?: string;           // present when run_async is true
 }
 ```
+
+### Response Format
+
+The bulk API returns batch metadata (not nested transaction objects). See **Bulk transaction response** above for the typed shape.
 
 ### Validation Rules
 
@@ -355,7 +360,7 @@ The bulk transactions API validates the following:
 1. **Required Fields**: `transactions` array must be provided and cannot be empty
 2. **Transaction Validation**: Each transaction in the array must pass standard transaction validation
 3. **Unique References**: All transaction references must be unique within the bulk request
-4. **Boolean Flags**: `atomic`, `inflight`, and `run_async` must be booleans if provided
+4. **Boolean Flags**: `atomic`, `inflight`, `run_async`, and `skip_queue` must be booleans if provided
 5. **Standard Transaction Rules**: All existing transaction validation rules apply to each transaction
 
 ### Error Handling

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -201,9 +201,10 @@ export class Transactions {
    *   - atomic: Optional boolean to ensure all transactions succeed or fail together
    *   - inflight: Optional boolean to create inflight transactions
    *   - run_async: Optional boolean to process transactions asynchronously
+   *   - skip_queue: Optional boolean to process without queuing
    *   - transactions: Array of transaction objects to be created
    *
-   * @returns {Promise<BulkTransactionResponse<T>>} A promise that resolves to the response
+   * @returns {Promise<BulkTransactionResponse>} A promise that resolves to the response
    * from the server after processing the bulk transactions.
    *
    * @throws {Error} Throws an error if the request fails, which will be logged using the
@@ -255,7 +256,7 @@ export class Transactions {
 
       const response = await this.request<
         BulkTransactions<T>,
-        BulkTransactionResponse<T>
+        BulkTransactionResponse
       >(`transactions/bulk`, payload, `POST`);
 
       if (response.data === null) {

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -573,6 +573,10 @@ export function ValidateBulkTransactions<T extends Record<string, unknown>>(
     return `Run_async must be a boolean if provided.`;
   }
 
+  if (data.skip_queue !== undefined && typeof data.skip_queue !== `boolean`) {
+    return `skip_queue must be a boolean if provided.`;
+  }
+
   if (!Array.isArray(data.transactions)) {
     return `Transactions must be an array.`;
   }

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -143,14 +143,25 @@ export interface BulkTransactions<T extends Record<string, unknown>> {
   atomic?: boolean;
   inflight?: boolean;
   run_async?: boolean;
+  /** Process synchronously without queuing. Default: `false`. */
+  skip_queue?: boolean;
   transactions: CreateTransactions<T>[];
 }
 
-export interface BulkTransactionResponse<T extends Record<string, unknown>> {
-  id: string;
-  atomic: boolean;
-  inflight: boolean;
-  run_async: boolean;
-  transactions: CreateTransactionResponse<T>[];
-  created_at: Date;
+/** Bulk batch status from `POST /transactions/bulk`. */
+export type BulkTransactionStatus = `applied` | `inflight` | `queued`;
+
+/**
+ * Response from `POST /transactions/bulk`.
+ * Field shapes follow the Blnk Core bulk-transactions reference.
+ *
+ * @see https://docs.blnkfinance.com/reference/bulk-transactions
+ */
+export interface BulkTransactionResponse {
+  batch_id: string;
+  status: BulkTransactionStatus | string;
+  /** Present when processing finished synchronously and the batch succeeded. */
+  transaction_count?: number;
+  /** Present when `run_async` is true (background processing started). */
+  message?: string;
 }

--- a/tests/fixtures/coreBulkTransactionResponse.ts
+++ b/tests/fixtures/coreBulkTransactionResponse.ts
@@ -1,0 +1,21 @@
+import {BulkTransactionResponse} from "../../src/types/transactions";
+
+/**
+ * Sample `POST /transactions/bulk` response from the Blnk Core API reference.
+ * @see https://docs.blnkfinance.com/reference/bulk-transactions
+ */
+export const coreBulkTransactionReferenceResponse: BulkTransactionResponse = {
+  batch_id: `bulk_c62f200b-905f-4983-a349-cadd279234aa`,
+  status: `applied`,
+  transaction_count: 4,
+};
+
+/**
+ * Async bulk response when `run_async` is true.
+ */
+export const coreBulkTransactionAsyncReferenceResponse: BulkTransactionResponse =
+  {
+    batch_id: `bulk_c62f200b-905f-4983-a349-cadd279234aa`,
+    status: `queued`,
+    message: `Bulk transaction processing started`,
+  };

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n/no-unpublished-import */
 /**
- * Integration tests for SDK changes in issues #40–#43.
+ * Integration tests for SDK changes in issues #40–#44.
  * Requires Blnk Core at http://localhost:5001 (docker compose up in blnk/).
  *
  * Run: npm run test:integration
@@ -11,6 +11,7 @@ import {BlnkClientOptions} from "../../src/types/blnkClient";
 import {CreateLedger} from "../../src/types/ledger";
 import {CreateLedgerBalance} from "../../src/types/ledgerBalances";
 import {
+  BulkTransactionResponse,
   BulkTransactions,
   CreateTransactions,
 } from "../../src/types/transactions";
@@ -103,13 +104,10 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
     } as BulkTransactions<Record<string, never>>);
 
     tt.equal(response.status, 201);
-    const bulk = response.data as {
-      transaction_count?: number;
-      batch_id?: string;
-      status?: string;
-    };
+    const bulk = response.data as BulkTransactionResponse;
     tt.equal(bulk?.transaction_count, 2, `Core accepted 2 bulk transactions`);
     tt.ok(bulk?.batch_id, `batch_id returned from Core`);
+    tt.type(bulk?.status, `string`, `status returned from Core`);
     tt.end();
   });
 
@@ -250,31 +248,34 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
   });
 
   // Issue #43 — CreateTransactionResponse parity (hash, parent_transaction, inflight)
-  t.test(`#43 create response includes hash, parent_transaction, inflight`, async tt => {
-    const response = await client.Transactions.create({
-      ...baseTxn,
-      amount: 1000,
-      reference: GenerateRandomNumbersWithPrefix(`issue43-resp`, 6),
-      source: `@FundingPool`,
-      destination: `@Recipient`,
-      allow_overdraft: false,
-      inflight: false,
-    } as CreateTransactions<Record<string, never>>);
+  t.test(
+    `#43 create response includes hash, parent_transaction, inflight`,
+    async tt => {
+      const response = await client.Transactions.create({
+        ...baseTxn,
+        amount: 1000,
+        reference: GenerateRandomNumbersWithPrefix(`issue43-resp`, 6),
+        source: `@FundingPool`,
+        destination: `@Recipient`,
+        allow_overdraft: false,
+        inflight: false,
+      } as CreateTransactions<Record<string, never>>);
 
-    tt.equal(response.status, 201);
-    tt.ok(response.data?.hash, `hash present`);
-    tt.equal(response.data?.hash?.length, 64, `hash is SHA-256 hex`);
-    tt.type(response.data?.parent_transaction, `string`);
-    tt.equal(response.data?.inflight, false);
-    tt.type(response.data?.allow_overdraft, `boolean`);
-    tt.equal(response.data?.scheduled_for, `0001-01-01T00:00:00Z`);
-    tt.equal(response.data?.inflight_expiry_date, `0001-01-01T00:00:00Z`);
-  // Core omits inflight_commit_date when inflight is false
-    if (response.data?.inflight_commit_date !== undefined) {
-      tt.type(response.data.inflight_commit_date, `string`);
-    }
-    tt.end();
-  });
+      tt.equal(response.status, 201);
+      tt.ok(response.data?.hash, `hash present`);
+      tt.equal(response.data?.hash?.length, 64, `hash is SHA-256 hex`);
+      tt.type(response.data?.parent_transaction, `string`);
+      tt.equal(response.data?.inflight, false);
+      tt.type(response.data?.allow_overdraft, `boolean`);
+      tt.equal(response.data?.scheduled_for, `0001-01-01T00:00:00Z`);
+      tt.equal(response.data?.inflight_expiry_date, `0001-01-01T00:00:00Z`);
+      // Core omits inflight_commit_date when inflight is false
+      if (response.data?.inflight_commit_date !== undefined) {
+        tt.type(response.data.inflight_commit_date, `string`);
+      }
+      tt.end();
+    },
+  );
 
   // Issue #43 — decimal percentage distributions with precise_amount
   t.test(`#43 decimal percentage split (33.33% / 66.67%)`, async tt => {
@@ -320,6 +321,43 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
     tt.ok(response.data?.transaction_id);
     tt.end();
   });
+
+  // Issue #44 — BulkTransactionResponse parity + skip_queue on bulk
+  t.test(
+    `#44 createBulk skip_queue + BulkTransactionResponse shape`,
+    async tt => {
+      const response = await client.Transactions.createBulk({
+        skip_queue: true,
+        transactions: [
+          {
+            ...baseTxn,
+            amount: 500,
+            reference: GenerateRandomNumbersWithPrefix(`issue44-bulk-1`, 6),
+            source: `@FundingPool`,
+            destination: `@Recipient`,
+          },
+          {
+            ...baseTxn,
+            amount: 750,
+            reference: GenerateRandomNumbersWithPrefix(`issue44-bulk-2`, 6),
+            source: `@FundingPool`,
+            destination: `@Recipient`,
+          },
+        ],
+      } as BulkTransactions<Record<string, never>>);
+
+      tt.equal(response.status, 201);
+      const bulk = response.data as BulkTransactionResponse;
+      tt.ok(bulk?.batch_id, `batch_id present`);
+      tt.type(bulk?.status, `string`, `status present`);
+      tt.equal(
+        bulk?.transaction_count,
+        2,
+        `transaction_count matches batch size`,
+      );
+      tt.end();
+    },
+  );
 
   t.end();
 });

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -141,10 +141,10 @@ tap.test(`Creates a transaction`, async t => {
 
   t.test(`returns Core create response fields (issue #43)`, async childTest => {
     const coreResponse = coreCreateTransactionReferenceResponse;
-    const responseReturningRequest: BlnkRequest = async () => ({
+    const responseReturningRequest: BlnkRequest = async <R>() => ({
       status: 201,
       message: `Success`,
-      data: coreResponse,
+      data: coreResponse as unknown as R,
     });
 
     const transactions = new Transactions(
@@ -761,6 +761,52 @@ tap.test(`Creates bulk transactions`, async t => {
       };
 
       const bulkResponse = await transactions.createBulk<meta_dataT>(data);
+      childTest.match(capturedRequest.args(), [
+        [`transactions/bulk`, data, `POST`],
+      ]);
+      childTest.equal(bulkResponse.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `createBulk forwards skip_queue on bulk request (issue #44)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: BulkTransactions<meta_dataT> = {
+        skip_queue: true,
+        transactions: [
+          {
+            amount: 1000,
+            currency: `USD`,
+            description: `Bulk txn with skip_queue`,
+            meta_data: {department: `sales`, project: `Q4_campaign`},
+            precision: 100,
+            reference: `bulk_skip_queue_001`,
+            source: `@source_account_1`,
+            destination: `@destination_account_1`,
+          },
+          {
+            amount: 2000,
+            currency: `USD`,
+            description: `Bulk txn 2`,
+            meta_data: {department: `marketing`, project: `Q4_campaign`},
+            precision: 100,
+            reference: `bulk_skip_queue_002`,
+            source: `@source_account_2`,
+            destination: `@destination_account_2`,
+          },
+        ],
+      };
+
+      const bulkResponse = await transactions.createBulk<meta_dataT>(data);
+
       childTest.match(capturedRequest.args(), [
         [`transactions/bulk`, data, `POST`],
       ]);

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -1,7 +1,13 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
-import {ValidateCreateTransactions} from "../../../../src/blnk/utils/validators/transactionValidators";
-import {CreateTransactions} from "../../../../src/types/transactions";
+import {
+  ValidateCreateTransactions,
+  ValidateBulkTransactions,
+} from "../../../../src/blnk/utils/validators/transactionValidators";
+import {
+  BulkTransactions,
+  CreateTransactions,
+} from "../../../../src/types/transactions";
 
 const baseFields = {
   precision: 100,
@@ -713,6 +719,46 @@ tap.test(`Issue #41 — ISO date strings and Distribution parity`, t => {
       tt.end();
     },
   );
+
+  t.end();
+});
+
+tap.test(`Issue #44 — bulk transaction request fields`, t => {
+  const baseBulkTxn: CreateTransactions<Record<string, never>> = {
+    ...baseFields,
+    amount: 1000,
+    source: `@FundingPool`,
+    destination: `@Recipient`,
+  };
+
+  t.test(`allows skip_queue on bulk payloads`, tt => {
+    const data: BulkTransactions<Record<string, never>> = {
+      skip_queue: true,
+      transactions: [
+        {...baseBulkTxn, reference: `bulk_ref_001`},
+        {...baseBulkTxn, reference: `bulk_ref_002`, amount: 2000},
+      ],
+    };
+
+    tt.equal(ValidateBulkTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid skip_queue on bulk payloads`, tt => {
+    const data = {
+      skip_queue: `true`,
+      transactions: [
+        {...baseBulkTxn, reference: `bulk_ref_001`},
+        {...baseBulkTxn, reference: `bulk_ref_002`, amount: 2000},
+      ],
+    } as unknown as BulkTransactions<Record<string, never>>;
+
+    tt.equal(
+      ValidateBulkTransactions(data),
+      `skip_queue must be a boolean if provided.`,
+    );
+    tt.end();
+  });
 
   t.end();
 });

--- a/tests/unit/types/bulkTransactionResponse.test.ts
+++ b/tests/unit/types/bulkTransactionResponse.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  coreBulkTransactionAsyncReferenceResponse,
+  coreBulkTransactionReferenceResponse,
+} from "../../fixtures/coreBulkTransactionResponse";
+import {BulkTransactionResponse} from "../../../src/types/transactions";
+
+tap.test(`Issue #44 — BulkTransactionResponse API parity`, t => {
+  t.test(`accepts Core API reference sync bulk response`, tt => {
+    const response: BulkTransactionResponse =
+      coreBulkTransactionReferenceResponse;
+
+    tt.equal(response.batch_id, `bulk_c62f200b-905f-4983-a349-cadd279234aa`);
+    tt.equal(response.status, `applied`);
+    tt.equal(response.transaction_count, 4);
+    tt.end();
+  });
+
+  t.test(`accepts Core API reference async bulk response`, tt => {
+    const response: BulkTransactionResponse =
+      coreBulkTransactionAsyncReferenceResponse;
+
+    tt.equal(response.batch_id, `bulk_c62f200b-905f-4983-a349-cadd279234aa`);
+    tt.equal(response.status, `queued`);
+    tt.equal(response.message, `Bulk transaction processing started`);
+    tt.end();
+  });
+
+  t.test(`batch_id field is present on reference response`, tt => {
+    tt.ok(coreBulkTransactionReferenceResponse.batch_id);
+    tt.end();
+  });
+
+  t.test(`status field is present on reference response`, tt => {
+    tt.type(coreBulkTransactionReferenceResponse.status, `string`);
+    tt.end();
+  });
+
+  t.test(`transaction_count is optional on async response`, tt => {
+    tt.equal(
+      coreBulkTransactionAsyncReferenceResponse.transaction_count,
+      undefined,
+    );
+    tt.end();
+  });
+
+  t.test(`accepts inflight bulk status`, tt => {
+    const inflightResponse: BulkTransactionResponse = {
+      batch_id: `bulk_4192d961-5b0e-46ca-bf2f-9386763057f8`,
+      status: `inflight`,
+      transaction_count: 2,
+    };
+
+    tt.equal(inflightResponse.status, `inflight`);
+    tt.equal(inflightResponse.transaction_count, 2);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `skip_queue` to bulk create request
- Align `BulkTransactionResponse` with Core API shape

Closes #44

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001) if available


Made with [Cursor](https://cursor.com)