### PR TITLE
Transactions.updateStatus: support precise_amount on partial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ const newTransaction = await Transactions.create({
 console.log("Transaction Recorded:", newTransaction);
 ```
 
+### Update inflight transaction status
+
+`Transactions.updateStatus` accepts `precise_amount` for partial commits on inflight transactions (in addition to `amount`). Omit both fields to commit the full remaining inflight amount:
+
+```typescript
+// Partial commit in minor units
+await Transactions.updateStatus(transactionId, {
+  status: 'commit',
+  precise_amount: 50000,
+});
+
+// Full commit
+await Transactions.updateStatus(transactionId, { status: 'commit' });
+```
+
 ### Create transaction response
 
 `Transactions.create` resolves to a `CreateTransactionResponse` that matches the Core API reference, including `hash`, `parent_transaction`, `allow_overdraft`, and inflight date fields (`scheduled_for`, `inflight_expiry_date`, `inflight_commit_date`):

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -544,11 +544,23 @@ export function ValidateUpdateTransactions<T extends Record<string, unknown>>(
     return `Amount must be a number.`;
   }
 
+  if (data.precise_amount !== undefined && data.precise_amount !== null) {
+    const isValidPreciseAmount =
+      typeof data.precise_amount === `number` ||
+      typeof data.precise_amount === `string`;
+    if (!isValidPreciseAmount) {
+      return `precise_amount must be a string or number.`;
+    }
+    if (parsePreciseInteger(data.precise_amount) === null) {
+      return `precise_amount must be a non-negative integer string or number.`;
+    }
+  }
+
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
   }
 
-  const allowedFields = [`status`, `amount`, `meta_data`];
+  const allowedFields = [`status`, `amount`, `precise_amount`, `meta_data`];
   for (const key in data) {
     if (!allowedFields.includes(key)) {
       return `Invalid field: ${key}`;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -135,7 +135,14 @@ export type Distribution =
 //so transaction.commit(id), transaction.commitPartial(id,amount)
 export type UpdateTransactionStatus<T extends Record<string, unknown>> = {
   status: InflightStatus;
+  /** Human-readable partial commit amount. Omit for full commit. */
   amount?: number;
+  /**
+   * Partial commit amount in minor units. Omit for full commit. Prefer strings
+   * for values larger than `Number.MAX_SAFE_INTEGER`. When both `amount` and
+   * `precise_amount` are set, Core uses `precise_amount`.
+   */
+  precise_amount?: number | string;
   meta_data?: T;
 };
 

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n/no-unpublished-import */
 /**
- * Integration tests for SDK changes in issues #40–#44.
+ * Integration tests for SDK changes in issues #40–#45.
  * Requires Blnk Core at http://localhost:5001 (docker compose up in blnk/).
  *
  * Run: npm run test:integration
@@ -358,6 +358,33 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
       tt.end();
     },
   );
+
+  // Issue #45 — partial commit with precise_amount on updateStatus
+  t.test(`#45 partial commit with precise_amount`, async tt => {
+    const ledgerId = await createLedger(`Issue45 PartialCommit`);
+    const destination = await createBalance(ledgerId);
+
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 1000,
+      reference: GenerateRandomNumbersWithPrefix(`issue45-inflight`, 6),
+      source: `@FundingPool`,
+      destination,
+      inflight: true,
+      inflight_expiry_date: `2026-12-31T23:59:59Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    await Sleep(2);
+
+    const partialCommitResp = await client.Transactions.updateStatus(
+      createResp.data!.transaction_id,
+      {status: `commit`, precise_amount: 50000},
+    );
+    tt.equal(partialCommitResp.status, 200);
+    tt.equal(partialCommitResp.data?.status, `APPLIED`);
+    tt.end();
+  });
 
   t.end();
 });

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -374,6 +374,30 @@ tap.test(`Updates a transaction`, async t => {
   });
 
   t.test(
+    `Partial commit forwards precise_amount (issue #45)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: UpdateTransactionStatus<{}> = {
+        status: `commit`,
+        precise_amount: 50000,
+      };
+
+      const transaction = await transactions.updateStatus(id, data);
+      childTest.match(capturedRequest.args(), [
+        [`transactions/inflight/${id}`, data, `PUT`],
+      ]);
+      childTest.equal(transaction.status, 200);
+      childTest.end();
+    },
+  );
+
+  t.test(
     `Updates fails for a transaction status with invalid data`,
     async childTest => {
       const capturedRequest = childTest.captureFn(thirdPartyRequest);

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -3,10 +3,12 @@ import tap from "tap";
 import {
   ValidateCreateTransactions,
   ValidateBulkTransactions,
+  ValidateUpdateTransactions,
 } from "../../../../src/blnk/utils/validators/transactionValidators";
 import {
   BulkTransactions,
   CreateTransactions,
+  UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
 
 const baseFields = {
@@ -757,6 +759,74 @@ tap.test(`Issue #44 — bulk transaction request fields`, t => {
       ValidateBulkTransactions(data),
       `skip_queue must be a boolean if provided.`,
     );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #45 — updateStatus precise_amount on partial commit`, t => {
+  t.test(`allows commit with precise_amount only`, tt => {
+    const data: UpdateTransactionStatus<Record<string, never>> = {
+      status: `commit`,
+      precise_amount: 50000,
+    };
+
+    tt.equal(ValidateUpdateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows precise_amount as a string for large integers`, tt => {
+    const data: UpdateTransactionStatus<Record<string, never>> = {
+      status: `commit`,
+      precise_amount: `9007199254740993`,
+    };
+
+    tt.equal(ValidateUpdateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows full commit without amount or precise_amount`, tt => {
+    const data: UpdateTransactionStatus<Record<string, never>> = {
+      status: `commit`,
+    };
+
+    tt.equal(ValidateUpdateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`allows amount and precise_amount together`, tt => {
+    const data: UpdateTransactionStatus<Record<string, never>> = {
+      status: `commit`,
+      amount: 500,
+      precise_amount: 50000,
+    };
+
+    tt.equal(ValidateUpdateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid precise_amount string values`, tt => {
+    const data: UpdateTransactionStatus<Record<string, never>> = {
+      status: `commit`,
+      precise_amount: `12.5`,
+    };
+
+    tt.equal(
+      ValidateUpdateTransactions(data),
+      `precise_amount must be a non-negative integer string or number.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects unknown fields`, tt => {
+    const data = {
+      status: `commit`,
+      precise_amount: 50000,
+      currency: `USD`,
+    } as unknown as UpdateTransactionStatus<Record<string, never>>;
+
+    tt.equal(ValidateUpdateTransactions(data), `Invalid field: currency`);
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Add `precise_amount` support to `Transactions.updateStatus` for partial commit

Closes #45

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001)

Made with [Cursor](https://cursor.com)