### PR TITLE
Transactions.refund: optional body with skip_queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ await Transactions.updateStatus(transactionId, {
 await Transactions.updateStatus(transactionId, { status: 'commit' });
 ```
 
+### Refund a transaction
+
+`Transactions.refund` accepts an optional body with `skip_queue` to process the refund synchronously. Omit the body to queue the refund (default):
+
+```typescript
+// Queued refund (default)
+await Transactions.refund(transactionId);
+
+// Synchronous refund
+await Transactions.refund(transactionId, { skip_queue: true });
+```
+
 ### Create transaction response
 
 `Transactions.create` resolves to a `CreateTransactionResponse` that matches the Core API reference, including `hash`, `parent_transaction`, `allow_overdraft`, and inflight date fields (`scheduled_for`, `inflight_expiry_date`, `inflight_commit_date`):

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -5,6 +5,7 @@ import {
   BulkTransactions,
   CreateTransactionResponse,
   CreateTransactions,
+  RefundTransactionRequest,
   UpdateTransactionStatus,
 } from "../../types/transactions";
 import {HandleError} from "../utils/logger";
@@ -12,6 +13,7 @@ import {serializeCreateTransaction} from "../utils/transactionSerialization";
 import {
   ValidateBulkTransactions,
   ValidateCreateTransactions,
+  ValidateRefundTransaction,
   ValidateUpdateTransactions,
 } from "../utils/validators/transactionValidators";
 
@@ -163,20 +165,31 @@ export class Transactions {
       see @link https://docs.blnkfinance.com/transactions/refunds
    *
    * @param id - The ID of the transaction to be refunded.
+   * @param options - Optional refund options (`skip_queue` for synchronous processing).
    * @returns A promise that resolves with the response of the refund transaction.
    * @throws If an error occurs during the refund process, an error response is returned.
    *
    * @example
    * const transactionId = "123456";
-   * const refundResponse = await refund<MyMetaDataType>(transactionId);
+   * const refundResponse = await Transactions.refund(transactionId);
+   * const syncRefund = await Transactions.refund(transactionId, { skip_queue: true });
    */
-  async refund<T extends Record<string, never>>(id: string) {
+  async refund<T extends Record<string, never>>(
+    id: string,
+    options?: RefundTransactionRequest,
+  ) {
     try {
-      const response = await this.request<null, CreateTransactionResponse<T>>(
-        `refund-transaction/${id}`,
-        null,
-        `POST`,
-      );
+      if (options !== undefined) {
+        const validatorResponse = ValidateRefundTransaction(options);
+        if (validatorResponse) {
+          return this.formatResponse(400, validatorResponse, null);
+        }
+      }
+
+      const response = await this.request<
+        RefundTransactionRequest | null,
+        CreateTransactionResponse<T>
+      >(`refund-transaction/${id}`, options ?? null, `POST`);
       return response;
     } catch (error: unknown) {
       return HandleError(

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -3,6 +3,7 @@ import {
   BulkTransactions,
   CreateTransactions,
   MultipleSourcesT,
+  RefundTransactionRequest,
   TransactionDateInput,
   UpdateTransactionStatus,
 } from "../../../types/transactions";
@@ -561,6 +562,23 @@ export function ValidateUpdateTransactions<T extends Record<string, unknown>>(
   }
 
   const allowedFields = [`status`, `amount`, `precise_amount`, `meta_data`];
+  for (const key in data) {
+    if (!allowedFields.includes(key)) {
+      return `Invalid field: ${key}`;
+    }
+  }
+
+  return null;
+}
+
+export function ValidateRefundTransaction(
+  data: RefundTransactionRequest,
+): string | null {
+  if (data.skip_queue !== undefined && typeof data.skip_queue !== `boolean`) {
+    return `skip_queue must be a boolean if provided.`;
+  }
+
+  const allowedFields = [`skip_queue`];
   for (const key in data) {
     if (!allowedFields.includes(key)) {
       return `Invalid field: ${key}`;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -146,6 +146,12 @@ export type UpdateTransactionStatus<T extends Record<string, unknown>> = {
   meta_data?: T;
 };
 
+/** Optional body for `POST /refund-transaction/{transaction_id}`. */
+export interface RefundTransactionRequest {
+  /** Process synchronously without queuing. Default: `false`. */
+  skip_queue?: boolean;
+}
+
 export interface BulkTransactions<T extends Record<string, unknown>> {
   atomic?: boolean;
   inflight?: boolean;

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable n/no-unpublished-import */
 /**
- * Integration tests for SDK changes in issues #40–#45.
+ * Integration tests for SDK changes in issues #40–#46.
  * Requires Blnk Core at http://localhost:5001 (docker compose up in blnk/).
  *
  * Run: npm run test:integration
@@ -383,6 +383,50 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
     );
     tt.equal(partialCommitResp.status, 200);
     tt.equal(partialCommitResp.data?.status, `APPLIED`);
+    tt.end();
+  });
+
+  // Issue #46 — refund with optional skip_queue body
+  t.test(`#46 refund queued vs synchronous skip_queue`, async tt => {
+    const ledgerId = await createLedger(`Issue46 Refund`);
+    const destination = await createBalance(ledgerId);
+
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 500,
+      reference: GenerateRandomNumbersWithPrefix(`issue46-refund-src`, 6),
+      source: `@FundingPool`,
+      destination,
+      skip_queue: true,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    tt.equal(createResp.data?.status, `APPLIED`);
+    const originalTxnId = createResp.data!.transaction_id;
+
+    const queuedRefundResp = await client.Transactions.refund(originalTxnId);
+    tt.equal(queuedRefundResp.status, 201);
+    tt.ok(queuedRefundResp.data?.transaction_id);
+    tt.equal(queuedRefundResp.data?.parent_transaction, originalTxnId);
+
+    const createResp2 = await client.Transactions.create({
+      ...baseTxn,
+      amount: 500,
+      reference: GenerateRandomNumbersWithPrefix(`issue46-refund-sync`, 6),
+      source: `@FundingPool`,
+      destination,
+      skip_queue: true,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp2.status, 201);
+    const originalTxnId2 = createResp2.data!.transaction_id;
+
+    const syncRefundResp = await client.Transactions.refund(originalTxnId2, {
+      skip_queue: true,
+    });
+    tt.equal(syncRefundResp.status, 201);
+    tt.equal(syncRefundResp.data?.status, `APPLIED`);
+    tt.equal(syncRefundResp.data?.parent_transaction, originalTxnId2);
     tt.end();
   });
 

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -12,6 +12,7 @@ import {
   BulkTransactions,
   CreateTransactionResponse,
   CreateTransactions,
+  RefundTransactionRequest,
   UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
 
@@ -418,6 +419,74 @@ tap.test(`Updates a transaction`, async t => {
       childTest.equal(transaction.status, 400);
     },
   );
+});
+
+tap.test(`Refunds a transaction`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+  });
+  const id = `txn_refund_1234`;
+
+  t.test(
+    `refund without body keeps backward-compatible call (issue #46)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const refundResponse = await transactions.refund(id);
+      childTest.match(capturedRequest.args(), [
+        [`refund-transaction/${id}`, null, `POST`],
+      ]);
+      childTest.equal(refundResponse.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `refund forwards skip_queue on request body (issue #46)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const options = {skip_queue: true};
+      const refundResponse = await transactions.refund(id, options);
+      childTest.match(capturedRequest.args(), [
+        [`refund-transaction/${id}`, options, `POST`],
+      ]);
+      childTest.equal(refundResponse.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(`refund rejects invalid skip_queue (issue #46)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const refundResponse = await transactions.refund(id, {
+      skip_queue: `true`,
+    } as unknown as RefundTransactionRequest);
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(refundResponse.status, 400);
+    childTest.equal(
+      refundResponse.message,
+      `skip_queue must be a boolean if provided.`,
+    );
+    childTest.end();
+  });
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -3,11 +3,13 @@ import tap from "tap";
 import {
   ValidateCreateTransactions,
   ValidateBulkTransactions,
+  ValidateRefundTransaction,
   ValidateUpdateTransactions,
 } from "../../../../src/blnk/utils/validators/transactionValidators";
 import {
   BulkTransactions,
   CreateTransactions,
+  RefundTransactionRequest,
   UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
 
@@ -827,6 +829,41 @@ tap.test(`Issue #45 — updateStatus precise_amount on partial commit`, t => {
     } as unknown as UpdateTransactionStatus<Record<string, never>>;
 
     tt.equal(ValidateUpdateTransactions(data), `Invalid field: currency`);
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #46 — refund transaction request fields`, t => {
+  t.test(`allows skip_queue on refund payloads`, tt => {
+    const data: RefundTransactionRequest = {skip_queue: true};
+    tt.equal(ValidateRefundTransaction(data), null);
+    tt.end();
+  });
+
+  t.test(`allows empty refund options object`, tt => {
+    const data: RefundTransactionRequest = {};
+    tt.equal(ValidateRefundTransaction(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid skip_queue on refund payloads`, tt => {
+    const data = {skip_queue: `true`} as unknown as RefundTransactionRequest;
+    tt.equal(
+      ValidateRefundTransaction(data),
+      `skip_queue must be a boolean if provided.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects unknown fields on refund payloads`, tt => {
+    const data = {
+      skip_queue: true,
+      amount: 100,
+    } as unknown as RefundTransactionRequest;
+
+    tt.equal(ValidateRefundTransaction(data), `Invalid field: amount`);
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Add optional refund body with `skip_queue` to `Transactions.refund`

Closes #46

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001)

Made with [Cursor](https://cursor.com)