### PR TITLE
feat(transactions): add Transactions.getByReference (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ const newTransaction = await Transactions.create({
 console.log("Transaction Recorded:", newTransaction);
 ```
 
+### Get transaction by reference
+
+`Transactions.getByReference` retrieves a transaction by its `reference` (GET `/transactions/reference/{reference}`):
+
+```typescript
+const response = await Transactions.getByReference('ref_04551509-d7d3-4eab-a1fd-2eb12809b5a4');
+```
+
 ### Update inflight transaction status
 
 `Transactions.updateStatus` accepts `precise_amount` for partial commits on inflight transactions (in addition to `amount`). Omit both fields to commit the full remaining inflight amount:

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -253,6 +253,40 @@ export class Transactions {
    * };
    * const result = await createBulk(bulkData);
    */
+  /**
+   * Retrieves a transaction by its reference.
+   *
+   * @param reference - The unique reference of the transaction to retrieve.
+   * @returns A promise that resolves with the transaction matching the reference.
+   *
+   * @example
+   * const response = await transactions.getByReference('ref_04551509-d7d3-4eab-a1fd-2eb12809b5a4');
+   */
+  async getByReference<T extends Record<string, unknown>>(reference: string) {
+    try {
+      if (!reference) {
+        return this.formatResponse(400, `reference is required`, null);
+      }
+
+      const response = await this.request<
+        undefined,
+        CreateTransactionResponse<T>
+      >(
+        `transactions/reference/${encodeURIComponent(reference)}`,
+        undefined,
+        `GET`,
+      );
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getByReference.name,
+      );
+    }
+  }
+
   async createBulk<T extends Record<string, unknown>>(
     data: BulkTransactions<T>,
   ) {

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -386,6 +386,28 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
     tt.end();
   });
 
+  // Issue #14 — get transaction by reference
+  t.test(`#14 getByReference returns created transaction`, async tt => {
+    const reference = GenerateRandomNumbersWithPrefix(`issue14-ref`, 6);
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 500,
+      reference,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    tt.ok(createResp.data?.transaction_id);
+
+    const getResp = await client.Transactions.getByReference(reference);
+    tt.equal(getResp.status, 200);
+    tt.equal(getResp.data?.transaction_id, createResp.data?.transaction_id);
+    tt.equal(getResp.data?.reference, reference);
+    tt.equal(getResp.data?.currency, `USD`);
+    tt.end();
+  });
+
   // Issue #46 — refund with optional skip_queue body
   t.test(`#46 refund queued vs synchronous skip_queue`, async tt => {
     const ledgerId = await createLedger(`Issue46 Refund`);

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -421,6 +421,76 @@ tap.test(`Updates a transaction`, async t => {
   );
 });
 
+tap.test(`GET transaction by reference`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(
+    `getByReference calls correct endpoint (issue #14)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const reference = `ref_issue14_abc123`;
+      const response = await transactions.getByReference(reference);
+      childTest.match(capturedRequest.args(), [
+        [
+          `transactions/reference/${encodeURIComponent(reference)}`,
+          undefined,
+          `GET`,
+        ],
+      ]);
+      childTest.equal(response.status, 200);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `getByReference path-escapes special characters (issue #14)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const reference = `ref/with space?query#hash%25`;
+      await transactions.getByReference(reference);
+      childTest.match(capturedRequest.args(), [
+        [
+          `transactions/reference/${encodeURIComponent(reference)}`,
+          undefined,
+          `GET`,
+        ],
+      ]);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `getByReference rejects empty reference (issue #14)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const response = await transactions.getByReference(``);
+      childTest.match(capturedRequest.args(), []);
+      childTest.equal(response.status, 400);
+      childTest.equal(response.message, `reference is required`);
+      childTest.end();
+    },
+  );
+});
+
 tap.test(`Refunds a transaction`, async t => {
   const mockLogger = createMockLogger();
   let thirdPartyRequest: BlnkRequest;


### PR DESCRIPTION
## Summary
- Add `Transactions.getByReference` for `GET /transactions/reference/{reference}`

Closes #14

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001)

Made with [Cursor](https://cursor.com)