### PR TITLE
feat(system): add System.health (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ docker compose up
 
 Once running, your server will be accessible at [http://localhost:5001](http://localhost:5001).
 
+### Health check
+
+`System.health` checks whether Blnk Core is running (GET `/health`):
+
+```typescript
+const health = await blnk.System.health();
+// { status: 'UP' }
+```
+
 ---
 
 ## 3. Using the Blnk CLI

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -12,6 +12,7 @@ import {LedgerBalances} from "./ledgerBalances";
 import {Ledgers} from "./ledgers";
 import {Reconciliation} from "./reconciliation";
 import {Search} from "./search";
+import {System} from "./system";
 import {Transactions} from "./transactions";
 import FormData from "form-data";
 
@@ -199,6 +200,10 @@ export class Blnk {
 
   get Identity(): Identity {
     return this.getService<Identity>(`Identity`);
+  }
+
+  get System(): System {
+    return this.getService<System>(`System`);
   }
 
   get getApiKey() {

--- a/src/blnk/endpoints/system.ts
+++ b/src/blnk/endpoints/system.ts
@@ -1,0 +1,50 @@
+import {BlnkLogger} from "../../types/blnkClient";
+import {BlnkRequest, FormatResponseType} from "../../types/general";
+import {HealthResponse} from "../../types/system";
+import {HandleError} from "../utils/logger";
+
+/**
+ * System operations for Blnk Core (health checks, etc.).
+ */
+export class System {
+  private request: BlnkRequest;
+  private logger: BlnkLogger;
+  private formatResponse: FormatResponseType;
+
+  constructor(
+    request: BlnkRequest,
+    logger: BlnkLogger,
+    formatResponse: FormatResponseType,
+  ) {
+    this.request = request;
+    this.logger = logger;
+    this.formatResponse = formatResponse;
+  }
+
+  /**
+   * Checks whether Blnk Core is running and reachable.
+   *
+   * @returns A promise that resolves with the health status (`{ status: 'UP' }`).
+   *
+   * @example
+   * const health = await client.System.health();
+   * // { status: 'UP' }
+   */
+  async health() {
+    try {
+      const response = await this.request<undefined, HealthResponse>(
+        `health`,
+        undefined,
+        `GET`,
+      );
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.health.name,
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {LedgerBalances} from "./blnk/endpoints/ledgerBalances";
 import {Ledgers} from "./blnk/endpoints/ledgers";
 import {Reconciliation} from "./blnk/endpoints/reconciliation";
 import {Search} from "./blnk/endpoints/search";
+import {System} from "./blnk/endpoints/system";
 import {Transactions} from "./blnk/endpoints/transactions";
 import {FormatResponse} from "./blnk/utils/httpClient";
 import {CustomLogger} from "./blnk/utils/logger";
@@ -28,6 +29,7 @@ export function BlnkInit(apiKey: string, options: BlnkClientOptions) {
       Reconciliation,
       Search,
       Identity,
+      System,
     },
     FormatResponse,
     fetch,

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -1,0 +1,3 @@
+export interface HealthResponse {
+  status: string;
+}

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -44,6 +44,14 @@ async function createBalance(ledgerId: string) {
 }
 
 tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
+  // Issue #39 — System.health
+  t.test(`#39 System.health returns UP`, async tt => {
+    const response = await client.System.health();
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.status, `UP`);
+    tt.end();
+  });
+
   // Issue #40 — Transactions.create with new Core fields
   t.test(`#40 skip_queue + effective_date`, async tt => {
     const response = await client.Transactions.create({

--- a/tests/unit/blnk/endpoints/system.test.ts
+++ b/tests/unit/blnk/endpoints/system.test.ts
@@ -1,0 +1,39 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {System} from "../../../../src/blnk/endpoints/system";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {
+  createMockBlnkRequest,
+  createMockLogger,
+} from "../../../mocks/blnkClientMocks";
+import {BlnkRequest} from "../../../../src/types/general";
+
+tap.test(`GET system health`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(`health calls GET /health (issue #39)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const system = new System(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await system.health();
+    childTest.match(capturedRequest.args(), [[`health`, undefined, `GET`]]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`health handles thrown errors (issue #39)`, async childTest => {
+    const errorRequest = createMockBlnkRequest(false, `Network error occurred`);
+    const capturedRequest = childTest.captureFn(errorRequest);
+    const system = new System(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await system.health();
+    childTest.match(capturedRequest.args(), [[`health`, undefined, `GET`]]);
+    childTest.equal(response.status, 500);
+    childTest.equal(response.message, `Network error occurred`);
+    childTest.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `System.health` for `GET /health`

Closes #39

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001)

Made with [Cursor](https://cursor.com)