### PR TITLE
Add Transactions.get (GET /transactions/{transaction_id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ const newTransaction = await Transactions.create({
 console.log("Transaction Recorded:", newTransaction);
 ```
 
+### Get transaction by ID
+
+`Transactions.get` retrieves a transaction by its `transaction_id` (GET `/transactions/{transaction_id}`):
+
+```typescript
+const response = await Transactions.get('txn_04551509-d7d3-4eab-a1fd-2eb12809b5a4');
+```
+
 ### Get transaction by reference
 
 `Transactions.getByReference` retrieves a transaction by its `reference` (GET `/transactions/reference/{reference}`):

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -254,6 +254,36 @@ export class Transactions {
    * const result = await createBulk(bulkData);
    */
   /**
+   * Retrieves a transaction by its ID.
+   *
+   * @param transactionId - The unique ID of the transaction to retrieve.
+   * @returns A promise that resolves with the transaction matching the ID.
+   *
+   * @example
+   * const response = await transactions.get('txn_04551509-d7d3-4eab-a1fd-2eb12809b5a4');
+   */
+  async get<T extends Record<string, unknown>>(transactionId: string) {
+    try {
+      if (!transactionId) {
+        return this.formatResponse(400, `transaction id is required`, null);
+      }
+
+      const response = await this.request<
+        undefined,
+        CreateTransactionResponse<T>
+      >(`transactions/${transactionId}`, undefined, `GET`);
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.get.name,
+      );
+    }
+  }
+
+  /**
    * Retrieves a transaction by its reference.
    *
    * @param reference - The unique reference of the transaction to retrieve.

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -394,6 +394,30 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
     tt.end();
   });
 
+  // Issue #12 — get transaction by id
+  t.test(`#12 get returns created transaction`, async tt => {
+    const reference = GenerateRandomNumbersWithPrefix(`issue12-ref`, 6);
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 500,
+      reference,
+      source: `@FundingPool`,
+      destination: `@Recipient`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    const transactionId = createResp.data!.transaction_id;
+    tt.ok(transactionId);
+
+    const getResp = await client.Transactions.get(transactionId);
+    tt.equal(getResp.status, 200);
+    tt.equal(getResp.data?.transaction_id, transactionId);
+    tt.equal(getResp.data?.reference, reference);
+    tt.equal(getResp.data?.currency, `USD`);
+    tt.type(getResp.data?.amount, `number`);
+    tt.end();
+  });
+
   // Issue #14 — get transaction by reference
   t.test(`#14 getByReference returns created transaction`, async tt => {
     const reference = GenerateRandomNumbersWithPrefix(`issue14-ref`, 6);

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -421,6 +421,44 @@ tap.test(`Updates a transaction`, async t => {
   );
 });
 
+tap.test(`GET transaction by id`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(`get calls correct endpoint (issue #12)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const transactionId = `txn_issue12_abc123`;
+    const response = await transactions.get(transactionId);
+    childTest.match(capturedRequest.args(), [
+      [`transactions/${transactionId}`, undefined, `GET`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`get rejects empty transaction id (issue #12)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await transactions.get(``);
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `transaction id is required`);
+    childTest.end();
+  });
+});
+
 tap.test(`GET transaction by reference`, async t => {
   const mockLogger = createMockLogger();
   let thirdPartyRequest: BlnkRequest;


### PR DESCRIPTION
## Summary
- Add `Transactions.get` for `GET /transactions/{transaction_id}`

Closes #12

## Test plan
- [x] unit tests pass
- [x] integration tests against local Core (:5001)

Made with [Cursor](https://cursor.com)