### PR TITLE
docs(system): fix System.health response example (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Once running, your server will be accessible at [http://localhost:5001](http://l
 
 ```typescript
 const health = await blnk.System.health();
-// { status: 'UP' }
+// health.status === 200
+// health.data?.status === 'UP'
 ```
 
 ---

--- a/src/blnk/endpoints/system.ts
+++ b/src/blnk/endpoints/system.ts
@@ -24,11 +24,12 @@ export class System {
   /**
    * Checks whether Blnk Core is running and reachable.
    *
-   * @returns A promise that resolves with the health status (`{ status: 'UP' }`).
+   * @returns Wrapped SDK response; Core payload is `{ status: 'UP' }` on `data`.
    *
    * @example
    * const health = await client.System.health();
-   * // { status: 'UP' }
+   * // health.status === 200
+   * // health.data?.status === 'UP'
    */
   async health() {
     try {


### PR DESCRIPTION
## Summary
- Fix README and JSDoc for `System.health` to show wrapped response shape (`response.status` + `response.data?.status`)
- Addresses Lukas review on #68 — implementation was correct; docs were misleading

Related: #39

## Test plan
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:unit` (297 pass)

Made with [Cursor](https://cursor.com)