### PR TITLE
feat(transactions): add bulkCommitInflight (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,25 @@ await Transactions.updateStatus(transactionId, {
 await Transactions.updateStatus(transactionId, { status: 'commit' });
 ```
 
+### Bulk commit inflight transactions
+
+`Transactions.bulkCommitInflight` commits multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/commit`). Omit `amount` and `precise_amount` on an item to commit the full remaining inflight amount:
+
+```typescript
+const response = await Transactions.bulkCommitInflight({
+  transactions: [
+    { transaction_id: 'txn_11111111-1111-4111-8111-111111111111' },
+    { transaction_id: 'txn_22222222-2222-4222-8222-222222222222', amount: 40 },
+    {
+      transaction_id: 'txn_33333333-3333-4333-8333-333333333333',
+      precise_amount: 125034,
+    },
+  ],
+});
+
+// response.data.succeeded, response.data.failed, response.data.results
+```
+
 ### Refund a transaction
 
 `Transactions.refund` accepts an optional body with `skip_queue` to process the refund synchronously. Omit the body to queue the refund (default):

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -1,6 +1,8 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
+  BulkCommitInflightRequest,
+  BulkCommitInflightResponse,
   BulkTransactionResponse,
   BulkTransactions,
   CreateTransactionResponse,
@@ -11,6 +13,7 @@ import {
 import {HandleError} from "../utils/logger";
 import {serializeCreateTransaction} from "../utils/transactionSerialization";
 import {
+  ValidateBulkCommitInflight,
   ValidateBulkTransactions,
   ValidateCreateTransactions,
   ValidateRefundTransaction,
@@ -27,6 +30,7 @@ import {
  * @method create - Creates a new transaction with the provided data.
  * @method createBulk - Creates multiple transactions in a single request with the provided data.
  * @method updateStatus - Updates the status of a transaction with the provided data.
+ * @method bulkCommitInflight - Commits multiple inflight transactions in one request.
  * @method refund - Refunds a transaction with the provided data.
  * @example
  * const transactions = new Transactions(requestFunction, loggerInstance, formatResponseFunction);
@@ -313,6 +317,41 @@ export class Transactions {
         this.logger,
         this.formatResponse,
         this.getByReference.name,
+      );
+    }
+  }
+
+  /**
+   * Commits multiple independently-created inflight transactions in one call.
+   *
+   * @see https://docs.blnkfinance.com/reference/bulk-commit-inflight
+   *
+   * @example
+   * const response = await blnk.Transactions.bulkCommitInflight({
+   *   transactions: [
+   *     { transaction_id: 'txn_11111111-1111-4111-8111-111111111111' },
+   *     { transaction_id: 'txn_22222222-2222-4222-8222-222222222222', amount: 40 },
+   *   ],
+   * });
+   */
+  async bulkCommitInflight(data: BulkCommitInflightRequest) {
+    try {
+      const validatorResponse = ValidateBulkCommitInflight(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<
+        BulkCommitInflightRequest,
+        BulkCommitInflightResponse
+      >(`transactions/inflight/bulk/commit`, data, `POST`);
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.bulkCommitInflight.name,
       );
     }
   }

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -1,7 +1,9 @@
 /* eslint-disable n/no-unsupported-features/es-builtins */
 import {
+  BulkCommitInflightRequest,
   BulkTransactions,
   CreateTransactions,
+  MAX_BULK_INFLIGHT_ITEMS,
   MultipleSourcesT,
   RefundTransactionRequest,
   TransactionDateInput,
@@ -582,6 +584,51 @@ export function ValidateRefundTransaction(
   for (const key in data) {
     if (!allowedFields.includes(key)) {
       return `Invalid field: ${key}`;
+    }
+  }
+
+  return null;
+}
+
+export function ValidateBulkCommitInflight(
+  data: BulkCommitInflightRequest,
+): string | null {
+  if (!Array.isArray(data.transactions)) {
+    return `Transactions must be an array.`;
+  }
+
+  if (data.transactions.length === 0) {
+    return `Transactions array cannot be empty.`;
+  }
+
+  if (data.transactions.length > MAX_BULK_INFLIGHT_ITEMS) {
+    return `Too many transactions; max is ${MAX_BULK_INFLIGHT_ITEMS}.`;
+  }
+
+  for (let i = 0; i < data.transactions.length; i++) {
+    const item = data.transactions[i];
+
+    if (
+      typeof item.transaction_id !== `string` ||
+      item.transaction_id.trim() === ``
+    ) {
+      return `transaction_id is required at index ${i}.`;
+    }
+
+    if (item.amount !== undefined && typeof item.amount !== `number`) {
+      return `amount must be a number at index ${i}.`;
+    }
+
+    if (item.precise_amount !== undefined && item.precise_amount !== null) {
+      const isValidPreciseAmount =
+        typeof item.precise_amount === `number` ||
+        typeof item.precise_amount === `string`;
+      if (!isValidPreciseAmount) {
+        return `precise_amount must be a string or number at index ${i}.`;
+      }
+      if (parsePreciseInteger(item.precise_amount) === null) {
+        return `precise_amount must be a non-negative integer string or number at index ${i}.`;
+      }
     }
   }
 

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -178,3 +178,47 @@ export interface BulkTransactionResponse {
   /** Present when `run_async` is true (background processing started). */
   message?: string;
 }
+
+/** Maximum items per bulk commit or bulk void inflight request. */
+export const MAX_BULK_INFLIGHT_ITEMS = 100;
+
+/** One transaction in `POST /transactions/inflight/bulk/commit`. */
+export interface BulkCommitInflightItem {
+  transaction_id: string;
+  /**
+   * Optional partial commit amount. When omitted or zero, Core commits the
+   * full remaining inflight amount.
+   */
+  amount?: number;
+  /**
+   * Optional partial commit amount in minor units. When set, takes precedence
+   * over `amount`. Prefer strings for values larger than `Number.MAX_SAFE_INTEGER`.
+   */
+  precise_amount?: number | string;
+}
+
+/** Request body for `POST /transactions/inflight/bulk/commit`. */
+export interface BulkCommitInflightRequest {
+  transactions: BulkCommitInflightItem[];
+}
+
+export type BulkInflightResultStatus = `succeeded` | `failed`;
+
+/** Per-item outcome in `BulkCommitInflightResponse`. */
+export interface BulkCommitInflightResult {
+  transaction_id: string;
+  status: BulkInflightResultStatus | string;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Response from `POST /transactions/inflight/bulk/commit`.
+ *
+ * @see https://docs.blnkfinance.com/reference/bulk-commit-inflight
+ */
+export interface BulkCommitInflightResponse {
+  succeeded: number;
+  failed: number;
+  results: BulkCommitInflightResult[];
+}

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -9,9 +9,11 @@ import {BlnkRequest} from "../../../../src/types/general";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import {coreCreateTransactionReferenceResponse} from "../../../fixtures/coreCreateTransactionResponse";
 import {
+  BulkCommitInflightRequest,
   BulkTransactions,
   CreateTransactionResponse,
   CreateTransactions,
+  MAX_BULK_INFLIGHT_ITEMS,
   RefundTransactionRequest,
   UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
@@ -1015,4 +1017,102 @@ tap.test(`Creates bulk transactions`, async t => {
       childTest.end();
     },
   );
+});
+
+tap.test(`Issue #15 — bulkCommitInflight`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(`commits inflight transactions with valid data`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const data: BulkCommitInflightRequest = {
+      transactions: [
+        {transaction_id: `txn_11111111-1111-4111-8111-111111111111`},
+        {
+          transaction_id: `txn_22222222-2222-4222-8222-222222222222`,
+          amount: 40,
+        },
+        {
+          transaction_id: `txn_33333333-3333-4333-8333-333333333333`,
+          precise_amount: 125034,
+        },
+      ],
+    };
+
+    const response = await transactions.bulkCommitInflight(data);
+
+    childTest.match(capturedRequest.args(), [
+      [`transactions/inflight/bulk/commit`, data, `POST`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`rejects empty transactions array`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await transactions.bulkCommitInflight({transactions: []});
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `Transactions array cannot be empty.`);
+    childTest.end();
+  });
+
+  t.test(`rejects too many transactions`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const items = Array.from({length: MAX_BULK_INFLIGHT_ITEMS + 1}, () => ({
+      transaction_id: `txn_test`,
+    }));
+
+    const response = await transactions.bulkCommitInflight({
+      transactions: items,
+    });
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `Too many transactions; max is ${MAX_BULK_INFLIGHT_ITEMS}.`,
+    );
+    childTest.end();
+  });
+
+  t.test(`rejects missing transaction_id`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await transactions.bulkCommitInflight({
+      transactions: [{transaction_id: ``}],
+    });
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `transaction_id is required at index 0.`);
+    childTest.end();
+  });
 });

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -2,13 +2,16 @@
 import tap from "tap";
 import {
   ValidateCreateTransactions,
+  ValidateBulkCommitInflight,
   ValidateBulkTransactions,
   ValidateRefundTransaction,
   ValidateUpdateTransactions,
 } from "../../../../src/blnk/utils/validators/transactionValidators";
 import {
+  BulkCommitInflightRequest,
   BulkTransactions,
   CreateTransactions,
+  MAX_BULK_INFLIGHT_ITEMS,
   RefundTransactionRequest,
   UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
@@ -864,6 +867,64 @@ tap.test(`Issue #46 — refund transaction request fields`, t => {
     } as unknown as RefundTransactionRequest;
 
     tt.equal(ValidateRefundTransaction(data), `Invalid field: amount`);
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #15 — bulkCommitInflight validation`, t => {
+  t.test(`allows valid bulk commit inflight payloads`, tt => {
+    const data: BulkCommitInflightRequest = {
+      transactions: [
+        {transaction_id: `txn_11111111-1111-4111-8111-111111111111`},
+        {
+          transaction_id: `txn_22222222-2222-4222-8222-222222222222`,
+          amount: 40,
+          precise_amount: `125034`,
+        },
+      ],
+    };
+
+    tt.equal(ValidateBulkCommitInflight(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects empty transactions array`, tt => {
+    tt.equal(
+      ValidateBulkCommitInflight({transactions: []}),
+      `Transactions array cannot be empty.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects oversized transactions array`, tt => {
+    const transactions = Array.from(
+      {length: MAX_BULK_INFLIGHT_ITEMS + 1},
+      () => ({transaction_id: `txn_test`}),
+    );
+
+    tt.equal(
+      ValidateBulkCommitInflight({transactions}),
+      `Too many transactions; max is ${MAX_BULK_INFLIGHT_ITEMS}.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid precise_amount`, tt => {
+    const data: BulkCommitInflightRequest = {
+      transactions: [
+        {
+          transaction_id: `txn_11111111-1111-4111-8111-111111111111`,
+          precise_amount: `-1`,
+        },
+      ],
+    };
+
+    tt.equal(
+      ValidateBulkCommitInflight(data),
+      `precise_amount must be a non-negative integer string or number at index 0.`,
+    );
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Adds `Transactions.bulkCommitInflight` for `POST /transactions/inflight/bulk/commit`
- Types, validation, unit tests, README example

Closes #15

## Test plan
- [x] `npm run test:unit -- --grep "Issue #15"` (8 tests pass)
- [x] Postgres verification queries in `blnk/scripts/sdk-tests/issue-15-bulk-commit-inflight.sql`