### PR TITLE
feat(transactions): add bulkVoidInflight (closes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,21 @@ const response = await Transactions.bulkCommitInflight({
 // response.data.succeeded, response.data.failed, response.data.results
 ```
 
+### Bulk void inflight transactions
+
+`Transactions.bulkVoidInflight` voids multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/void`):
+
+```typescript
+const response = await Transactions.bulkVoidInflight({
+  transaction_ids: [
+    'txn_11111111-1111-4111-8111-111111111111',
+    'txn_22222222-2222-4222-8222-222222222222',
+  ],
+});
+
+// response.data.succeeded, response.data.failed, response.data.results
+```
+
 ### Refund a transaction
 
 `Transactions.refund` accepts an optional body with `skip_queue` to process the refund synchronously. Omit the body to queue the refund (default):

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -3,6 +3,8 @@ import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
   BulkCommitInflightRequest,
   BulkCommitInflightResponse,
+  BulkVoidInflightRequest,
+  BulkVoidInflightResponse,
   BulkTransactionResponse,
   BulkTransactions,
   CreateTransactionResponse,
@@ -14,6 +16,7 @@ import {HandleError} from "../utils/logger";
 import {serializeCreateTransaction} from "../utils/transactionSerialization";
 import {
   ValidateBulkCommitInflight,
+  ValidateBulkVoidInflight,
   ValidateBulkTransactions,
   ValidateCreateTransactions,
   ValidateRefundTransaction,
@@ -352,6 +355,41 @@ export class Transactions {
         this.logger,
         this.formatResponse,
         this.bulkCommitInflight.name,
+      );
+    }
+  }
+
+  /**
+   * Voids multiple independently-created inflight transactions in one call.
+   *
+   * @see https://docs.blnkfinance.com/reference/bulk-void-inflight
+   *
+   * @example
+   * const response = await blnk.Transactions.bulkVoidInflight({
+   *   transaction_ids: [
+   *     'txn_11111111-1111-4111-8111-111111111111',
+   *     'txn_22222222-2222-4222-8222-222222222222',
+   *   ],
+   * });
+   */
+  async bulkVoidInflight(data: BulkVoidInflightRequest) {
+    try {
+      const validatorResponse = ValidateBulkVoidInflight(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<
+        BulkVoidInflightRequest,
+        BulkVoidInflightResponse
+      >(`transactions/inflight/bulk/void`, data, `POST`);
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.bulkVoidInflight.name,
       );
     }
   }

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -1,6 +1,7 @@
 /* eslint-disable n/no-unsupported-features/es-builtins */
 import {
   BulkCommitInflightRequest,
+  BulkVoidInflightRequest,
   BulkTransactions,
   CreateTransactions,
   MAX_BULK_INFLIGHT_ITEMS,
@@ -584,6 +585,32 @@ export function ValidateRefundTransaction(
   for (const key in data) {
     if (!allowedFields.includes(key)) {
       return `Invalid field: ${key}`;
+    }
+  }
+
+  return null;
+}
+
+export function ValidateBulkVoidInflight(
+  data: BulkVoidInflightRequest,
+): string | null {
+  if (!Array.isArray(data.transaction_ids)) {
+    return `transaction_ids must be an array.`;
+  }
+
+  if (data.transaction_ids.length === 0) {
+    return `transaction_ids array cannot be empty.`;
+  }
+
+  if (data.transaction_ids.length > MAX_BULK_INFLIGHT_ITEMS) {
+    return `Too many transaction_ids; max is ${MAX_BULK_INFLIGHT_ITEMS}.`;
+  }
+
+  for (let i = 0; i < data.transaction_ids.length; i++) {
+    const id = data.transaction_ids[i];
+
+    if (typeof id !== `string` || id.trim() === ``) {
+      return `transaction_id is required at index ${i}.`;
     }
   }
 

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -222,3 +222,27 @@ export interface BulkCommitInflightResponse {
   failed: number;
   results: BulkCommitInflightResult[];
 }
+
+/** Request body for `POST /transactions/inflight/bulk/void`. */
+export interface BulkVoidInflightRequest {
+  transaction_ids: string[];
+}
+
+/** Per-item outcome in `BulkVoidInflightResponse`. */
+export interface BulkVoidInflightResult {
+  transaction_id: string;
+  status: BulkInflightResultStatus | string;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Response from `POST /transactions/inflight/bulk/void`.
+ *
+ * @see https://docs.blnkfinance.com/reference/bulk-void-inflight
+ */
+export interface BulkVoidInflightResponse {
+  succeeded: number;
+  failed: number;
+  results: BulkVoidInflightResult[];
+}

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -10,6 +10,7 @@ import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import {coreCreateTransactionReferenceResponse} from "../../../fixtures/coreCreateTransactionResponse";
 import {
   BulkCommitInflightRequest,
+  BulkVoidInflightRequest,
   BulkTransactions,
   CreateTransactionResponse,
   CreateTransactions,
@@ -1108,6 +1109,96 @@ tap.test(`Issue #15 — bulkCommitInflight`, async t => {
 
     const response = await transactions.bulkCommitInflight({
       transactions: [{transaction_id: ``}],
+    });
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `transaction_id is required at index 0.`);
+    childTest.end();
+  });
+});
+
+tap.test(`Issue #16 — bulkVoidInflight`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(`voids inflight transactions with valid data`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const data: BulkVoidInflightRequest = {
+      transaction_ids: [
+        `txn_11111111-1111-4111-8111-111111111111`,
+        `txn_22222222-2222-4222-8222-222222222222`,
+      ],
+    };
+
+    const response = await transactions.bulkVoidInflight(data);
+
+    childTest.match(capturedRequest.args(), [
+      [`transactions/inflight/bulk/void`, data, `POST`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`rejects empty transaction_ids array`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await transactions.bulkVoidInflight({transaction_ids: []});
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `transaction_ids array cannot be empty.`);
+    childTest.end();
+  });
+
+  t.test(`rejects too many transaction_ids`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const transaction_ids = Array.from(
+      {length: MAX_BULK_INFLIGHT_ITEMS + 1},
+      () => `txn_test`,
+    );
+
+    const response = await transactions.bulkVoidInflight({transaction_ids});
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `Too many transaction_ids; max is ${MAX_BULK_INFLIGHT_ITEMS}.`,
+    );
+    childTest.end();
+  });
+
+  t.test(`rejects missing transaction_id`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await transactions.bulkVoidInflight({
+      transaction_ids: [``],
     });
 
     childTest.match(capturedRequest.args(), []);

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -3,12 +3,14 @@ import tap from "tap";
 import {
   ValidateCreateTransactions,
   ValidateBulkCommitInflight,
+  ValidateBulkVoidInflight,
   ValidateBulkTransactions,
   ValidateRefundTransaction,
   ValidateUpdateTransactions,
 } from "../../../../src/blnk/utils/validators/transactionValidators";
 import {
   BulkCommitInflightRequest,
+  BulkVoidInflightRequest,
   BulkTransactions,
   CreateTransactions,
   MAX_BULK_INFLIGHT_ITEMS,
@@ -924,6 +926,51 @@ tap.test(`Issue #15 — bulkCommitInflight validation`, t => {
     tt.equal(
       ValidateBulkCommitInflight(data),
       `precise_amount must be a non-negative integer string or number at index 0.`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #16 — bulkVoidInflight validation`, t => {
+  t.test(`allows valid bulk void inflight payloads`, tt => {
+    const data: BulkVoidInflightRequest = {
+      transaction_ids: [
+        `txn_11111111-1111-4111-8111-111111111111`,
+        `txn_22222222-2222-4222-8222-222222222222`,
+      ],
+    };
+
+    tt.equal(ValidateBulkVoidInflight(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects empty transaction_ids array`, tt => {
+    tt.equal(
+      ValidateBulkVoidInflight({transaction_ids: []}),
+      `transaction_ids array cannot be empty.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects oversized transaction_ids array`, tt => {
+    const transaction_ids = Array.from(
+      {length: MAX_BULK_INFLIGHT_ITEMS + 1},
+      () => `txn_test`,
+    );
+
+    tt.equal(
+      ValidateBulkVoidInflight({transaction_ids}),
+      `Too many transaction_ids; max is ${MAX_BULK_INFLIGHT_ITEMS}.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects missing transaction_id`, tt => {
+    tt.equal(
+      ValidateBulkVoidInflight({transaction_ids: [``]}),
+      `transaction_id is required at index 0.`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Adds `Transactions.bulkVoidInflight` for `POST /transactions/inflight/bulk/void`
- Adds `BulkVoidInflightRequest` / `BulkVoidInflightResponse` types aligned with the [bulk void inflight reference](https://docs.blnkfinance.com/reference/bulk-void-inflight)
- Client-side validation: non-empty `transaction_ids`, max 100 items, required non-blank ids
- Unit tests (endpoint + validator) and README example

## Acceptance criteria
- [x] `Transactions.bulkVoidInflight` calling `/transactions/inflight/bulk/void`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules (empty list, max 100, required ids)
- [x] Unit tests with mocked HTTP
- [x] README example

## Test plan
- [x] `npm run test:unit` — 331 passed
- [x] `npm run lint` — clean
- [x] `npm run test:unit -- --grep "Issue #16"` — 8 tests passed
- [x] Postman: **TS SDK (#16)** folder in *Blnk SDK Issues — Local Core Tests (fixed)* against Core **0.14.5**
  - Create 2 inflight txns → bulk void (`skip_queue: true`) → GET + re-void rejected

Closes #16