### PR TITLE
feat(transactions): expose atomic on split create requests (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,27 @@ const newTransaction = await Transactions.create({
 console.log("Transaction Recorded:", newTransaction);
 ```
 
+### Atomic split transactions
+
+Set `atomic: true` when creating a split transaction (`destinations` or `sources`) so all legs succeed or fail together:
+
+```typescript
+const response = await Transactions.create({
+  amount: 1000,
+  precision: 100,
+  reference: 'atomic_split_ref_001',
+  description: 'Atomic fee split',
+  currency: 'USD',
+  source: '@FundingPool',
+  destinations: [
+    { identifier: 'bln_fee', distribution: '240.23' },
+    { identifier: 'bln_recipient', distribution: 'left' },
+  ],
+  atomic: true,
+  skip_queue: true,
+});
+```
+
 ### Get transaction by ID
 
 `Transactions.get` retrieves a transaction by its `transaction_id` (GET `/transactions/{transaction_id}`):

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -285,6 +285,10 @@ export function ValidateCreateTransactions<T extends Record<string, unknown>>(
     return `skip_queue must be a boolean if provided.`;
   }
 
+  if (data.atomic !== undefined && typeof data.atomic !== `boolean`) {
+    return `atomic must be a boolean if provided.`;
+  }
+
   if (
     data.allow_overdraft !== undefined &&
     typeof data.allow_overdraft !== `boolean`

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -38,6 +38,11 @@ export interface CreateTransactions<T extends Record<string, unknown>> {
   effective_date?: TransactionDateInput;
   /** Process synchronously without queuing. Default: `false`. */
   skip_queue?: boolean;
+  /**
+   * When true on a split transaction (`sources` or `destinations`), all legs
+   * succeed or fail together. Optional; omit for default Core behavior.
+   */
+  atomic?: boolean;
   allow_overdraft?: boolean;
   meta_data?: T;
 }

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -143,6 +143,70 @@ tap.test(`Creates a transaction`, async t => {
     },
   );
 
+  t.test(
+    `forwards atomic on split transaction create (issue #5)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: CreateTransactions<meta_dataT> = {
+        amount: 1000,
+        currency: `USD`,
+        description: `Atomic split transaction`,
+        meta_data: {company_name: `Test Company`},
+        precision: 100,
+        reference: `issue_5_atomic_split`,
+        source: `@FundingPool`,
+        destinations: [
+          {identifier: `bln_fee`, distribution: `240.23`},
+          {identifier: `bln_recipient`, distribution: `left`},
+        ],
+        atomic: true,
+        skip_queue: true,
+      };
+
+      const transaction = await transactions.create<meta_dataT>(data);
+
+      childTest.match(capturedRequest.args(), [[`transactions`, data, `POST`]]);
+      childTest.equal(transaction.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(`rejects invalid atomic on create (issue #5)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const data = {
+      amount: 1000,
+      currency: `USD`,
+      description: `Invalid atomic`,
+      precision: 100,
+      reference: `issue_5_bad_atomic`,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `50%`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+      atomic: `true`,
+    } as unknown as CreateTransactions<meta_dataT>;
+
+    const response = await transactions.create<meta_dataT>(data);
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `atomic must be a boolean if provided.`);
+    childTest.end();
+  });
+
   t.test(`returns Core create response fields (issue #43)`, async childTest => {
     const coreResponse = coreCreateTransactionReferenceResponse;
     const responseReturningRequest: BlnkRequest = async <R>() => ({

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -25,6 +25,51 @@ const baseFields = {
   currency: `USD`,
 };
 
+tap.test(`Issue #5 — atomic on split transactions`, t => {
+  t.test(`allows atomic on split create payloads`, tt => {
+    const data: CreateTransactions<Record<string, unknown>> = {
+      amount: 1000,
+      precision: 100,
+      reference: `ref_atomic_split`,
+      description: `Atomic split`,
+      currency: `USD`,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `50%`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+      atomic: true,
+    };
+
+    tt.equal(ValidateCreateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects non-boolean atomic`, tt => {
+    const data = {
+      amount: 1000,
+      precision: 100,
+      reference: `ref_bad_atomic`,
+      description: `Bad atomic`,
+      currency: `USD`,
+      source: `@FundingPool`,
+      destinations: [
+        {identifier: `bln_fee`, distribution: `50%`},
+        {identifier: `bln_recipient`, distribution: `left`},
+      ],
+      atomic: `true`,
+    } as unknown as CreateTransactions<Record<string, unknown>>;
+
+    tt.equal(
+      ValidateCreateTransactions(data),
+      `atomic must be a boolean if provided.`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});
+
 tap.test(`Issue #42 — split-transaction validator`, t => {
   t.test(`allows multiple sources with a single destination`, tt => {
     const data: CreateTransactions<Record<string, never>> = {


### PR DESCRIPTION
## Summary
- Adds optional `atomic` to `CreateTransactions` for split transactions (`sources` / `destinations`)
- Validates `atomic` is a boolean when provided
- Ensures the field is serialized and sent to `POST /transactions` via existing `serializeCreateTransaction` spread
- README example for atomic split transactions

## Scope (issue #5)
- [x] Add `atomic` to split transaction request models
- [x] Field serialized and sent to API when provided
- [x] Backward compatible — field remains optional
- [x] SDK example in README

## Test plan
- [x] `npm run test:unit` — 341 passed
- [x] `npm run lint` — clean
- [x] Postman: **TS SDK (#5)** folder in *Blnk SDK Issues — Local Core Tests (fixed)*
  - Run **Setup** first, then **TS SDK (#5)** (atomic split create + GET verify)

Closes #5