### PR TITLE
feat(transactions): add getLineage (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,18 @@ const response = await Transactions.get('txn_04551509-d7d3-4eab-a1fd-2eb12809b5a
 const response = await Transactions.getByReference('ref_04551509-d7d3-4eab-a1fd-2eb12809b5a4');
 ```
 
+### Get transaction lineage
+
+`Transactions.getLineage` retrieves fund allocation and shadow transactions for a transaction (GET `/transactions/{transaction_id}/lineage`):
+
+```typescript
+const response = await Transactions.getLineage('txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad');
+
+// response.data.transaction_id
+// response.data.fund_allocation
+// response.data.shadow_transactions
+```
+
 ### Update inflight transaction status
 
 `Transactions.updateStatus` accepts `precise_amount` for partial commits on inflight transactions (in addition to `amount`). Omit both fields to commit the full remaining inflight amount:

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -10,6 +10,7 @@ import {
   CreateTransactionResponse,
   CreateTransactions,
   RefundTransactionRequest,
+  TransactionLineageResponse,
   UpdateTransactionStatus,
 } from "../../types/transactions";
 import {HandleError} from "../utils/logger";
@@ -320,6 +321,35 @@ export class Transactions {
         this.logger,
         this.formatResponse,
         this.getByReference.name,
+      );
+    }
+  }
+
+  /**
+   * Retrieves fund lineage for a transaction (allocation and shadow transactions).
+   *
+   * @see https://docs.blnkfinance.com/reference/get-transaction-lineage
+   *
+   * @example
+   * const response = await transactions.getLineage('txn_8d2ce2f0-0d75-4a91-9d43-2ad2c2e6b9ad');
+   */
+  async getLineage<T extends Record<string, unknown>>(transactionId: string) {
+    try {
+      if (!transactionId) {
+        return this.formatResponse(400, `transaction id is required`, null);
+      }
+
+      const response = await this.request<
+        undefined,
+        TransactionLineageResponse<T>
+      >(`transactions/${transactionId}/lineage`, undefined, `GET`);
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getLineage.name,
       );
     }
   }

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -251,3 +251,41 @@ export interface BulkVoidInflightResponse {
   failed: number;
   results: BulkVoidInflightResult[];
 }
+
+/** One provider entry in `TransactionLineageResponse.fund_allocation`. */
+export type TransactionLineageFundAllocation = Record<
+  string,
+  string | number | boolean | null
+>;
+
+/**
+ * Shadow transaction created for fund lineage tracking.
+ * Items mirror Core transaction objects; fields vary by lineage type.
+ */
+export type TransactionLineageShadowTransaction<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  transaction_id: string;
+  reference?: string;
+  precise_amount?: number | string;
+  amount?: number;
+  precision?: number;
+  currency?: string;
+  status?: StatusType | string;
+  parent_transaction?: string;
+  meta_data?: T;
+} & Record<string, unknown>;
+
+/**
+ * Response from `GET /transactions/{transaction_id}/lineage`.
+ *
+ * @see https://docs.blnkfinance.com/reference/get-transaction-lineage
+ */
+export interface TransactionLineageResponse<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> {
+  transaction_id: string;
+  /** Present for debits from lineage-enabled balances. Amounts are minor units. */
+  fund_allocation?: TransactionLineageFundAllocation[];
+  shadow_transactions: TransactionLineageShadowTransaction<T>[];
+}

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -286,6 +286,7 @@ export interface TransactionLineageResponse<
 > {
   transaction_id: string;
   /** Present for debits from lineage-enabled balances. Amounts are minor units. */
-  fund_allocation?: TransactionLineageFundAllocation[];
-  shadow_transactions: TransactionLineageShadowTransaction<T>[];
+  fund_allocation?: TransactionLineageFundAllocation[] | null;
+  /** Empty when no shadow transactions exist; Core may return `null`. */
+  shadow_transactions: TransactionLineageShadowTransaction<T>[] | null;
 }

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -526,6 +526,47 @@ tap.test(`GET transaction by id`, async t => {
   });
 });
 
+tap.test(`GET transaction lineage`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(`getLineage calls correct endpoint (issue #13)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const transactionId = `txn_issue13_abc123`;
+    const response = await transactions.getLineage(transactionId);
+    childTest.match(capturedRequest.args(), [
+      [`transactions/${transactionId}/lineage`, undefined, `GET`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(
+    `getLineage rejects empty transaction id (issue #13)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const response = await transactions.getLineage(``);
+      childTest.match(capturedRequest.args(), []);
+      childTest.equal(response.status, 400);
+      childTest.equal(response.message, `transaction id is required`);
+      childTest.end();
+    },
+  );
+});
+
 tap.test(`GET transaction by reference`, async t => {
   const mockLogger = createMockLogger();
   let thirdPartyRequest: BlnkRequest;


### PR DESCRIPTION
## Summary
- Add `Transactions.getLineage(transactionId)` calling `GET /transactions/{transaction_id}/lineage`
- Add `TransactionLineageResponse` types for `fund_allocation` and `shadow_transactions`
- Unit tests (endpoint + empty-id validation) and README example
- Postman folder **TS SDK (#13)** in cloud collection (setup txn + lineage GET)

## Acceptance criteria
- [x] `Transactions.getLineage` → `/transactions/{transaction_id}/lineage`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation (required `transaction_id`, same as `get`)
- [x] Unit tests with mocked HTTP
- [x] README example

## Test plan
- [x] `npm run test:unit` (348 passing)
- [x] `npm run lint`
- [ ] Postman: run **TS SDK (#13)** folder top to bottom against Core 0.14.5