### PR TITLE
feat(transactions): add recoverQueue (closes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ const response = await Transactions.get('txn_04551509-d7d3-4eab-a1fd-2eb12809b5a
 const response = await Transactions.getByReference('ref_04551509-d7d3-4eab-a1fd-2eb12809b5a4');
 ```
 
+### Recover queued transactions
+
+`Transactions.recoverQueue` manually triggers recovery of stuck queued transactions (`POST /transactions/recover`). Optionally pass a `threshold` duration query (e.g. `5m`, `1h`):
+
+```typescript
+const response = await Transactions.recoverQueue({ threshold: '5m' });
+
+// response.data.recovered, response.data.threshold
+```
+
 ### Get transaction lineage
 
 `Transactions.getLineage` retrieves fund allocation and shadow transactions for a transaction (GET `/transactions/{transaction_id}/lineage`):

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -9,6 +9,8 @@ import {
   BulkTransactions,
   CreateTransactionResponse,
   CreateTransactions,
+  RecoverQueueRequest,
+  RecoverQueueResponse,
   RefundTransactionRequest,
   TransactionLineageResponse,
   UpdateTransactionStatus,
@@ -20,6 +22,7 @@ import {
   ValidateBulkVoidInflight,
   ValidateBulkTransactions,
   ValidateCreateTransactions,
+  ValidateRecoverQueue,
   ValidateRefundTransaction,
   ValidateUpdateTransactions,
 } from "../utils/validators/transactionValidators";
@@ -350,6 +353,44 @@ export class Transactions {
         this.logger,
         this.formatResponse,
         this.getLineage.name,
+      );
+    }
+  }
+
+  /**
+   * Manually triggers recovery of stuck queued transactions.
+   *
+   * @see https://docs.blnkfinance.com/reference/queue-recovery
+   *
+   * @example
+   * const response = await transactions.recoverQueue({ threshold: '5m' });
+   * // response.data.recovered, response.data.threshold
+   */
+  async recoverQueue(options?: RecoverQueueRequest) {
+    try {
+      if (options !== undefined) {
+        const validatorResponse = ValidateRecoverQueue(options);
+        if (validatorResponse) {
+          return this.formatResponse(400, validatorResponse, null);
+        }
+      }
+
+      const endpoint = options?.threshold
+        ? `transactions/recover?threshold=${encodeURIComponent(options.threshold)}`
+        : `transactions/recover`;
+
+      const response = await this.request<undefined, RecoverQueueResponse>(
+        endpoint,
+        undefined,
+        `POST`,
+      );
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.recoverQueue.name,
       );
     }
   }

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -6,6 +6,7 @@ import {
   CreateTransactions,
   MAX_BULK_INFLIGHT_ITEMS,
   MultipleSourcesT,
+  RecoverQueueRequest,
   RefundTransactionRequest,
   TransactionDateInput,
   UpdateTransactionStatus,
@@ -705,6 +706,38 @@ export function ValidateBulkTransactions<T extends Record<string, unknown>>(
   const uniqueReferences = new Set(references);
   if (references.length !== uniqueReferences.size) {
     return `All transactions must have unique references within the bulk request.`;
+  }
+
+  return null;
+}
+
+const GO_DURATION_UNIT = `(?:ns|us|µs|ms|s|m|h)`;
+const GO_DURATION_PATTERN = new RegExp(
+  `^(?:\\d+(?:\\.\\d+)?${GO_DURATION_UNIT})+$`,
+);
+
+function isValidGoDuration(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && GO_DURATION_PATTERN.test(trimmed);
+}
+
+export function ValidateRecoverQueue(data: RecoverQueueRequest): string | null {
+  const allowedFields = [`threshold`];
+  for (const key in data) {
+    if (!allowedFields.includes(key)) {
+      return `Invalid field: ${key}`;
+    }
+  }
+
+  if (data.threshold === undefined) {
+    return null;
+  }
+
+  if (
+    typeof data.threshold !== `string` ||
+    !isValidGoDuration(data.threshold)
+  ) {
+    return `threshold must be a valid duration string (e.g. 5m, 1h).`;
   }
 
   return null;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -290,3 +290,24 @@ export interface TransactionLineageResponse<
   /** Empty when no shadow transactions exist; Core may return `null`. */
   shadow_transactions: TransactionLineageShadowTransaction<T>[] | null;
 }
+
+/** Optional query options for `POST /transactions/recover`. */
+export interface RecoverQueueRequest {
+  /**
+   * Minimum age of queued transactions to recover (Go duration string).
+   * Examples: `5m`, `10m`, `1h`. Core default: `2m`.
+   */
+  threshold?: string;
+}
+
+/**
+ * Response from `POST /transactions/recover`.
+ *
+ * @see https://docs.blnkfinance.com/reference/queue-recovery
+ */
+export interface RecoverQueueResponse {
+  /** Number of transactions re-enqueued for processing. */
+  recovered: number;
+  /** Threshold duration Core applied (e.g. `5m0s`). */
+  threshold: string;
+}

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -567,6 +567,67 @@ tap.test(`GET transaction lineage`, async t => {
   );
 });
 
+tap.test(`POST recover queued transactions`, async t => {
+  const mockLogger = createMockLogger();
+  let thirdPartyRequest: BlnkRequest;
+  t.beforeEach(() => {
+    thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+  });
+
+  t.test(`recoverQueue calls default endpoint (issue #17)`, async childTest => {
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const transactions = new Transactions(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await transactions.recoverQueue();
+    childTest.match(capturedRequest.args(), [
+      [`transactions/recover`, undefined, `POST`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(
+    `recoverQueue forwards threshold query param (issue #17)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const response = await transactions.recoverQueue({threshold: `5m`});
+      childTest.match(capturedRequest.args(), [
+        [`transactions/recover?threshold=5m`, undefined, `POST`],
+      ]);
+      childTest.equal(response.status, 200);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `recoverQueue rejects invalid threshold before request (issue #17)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const response = await transactions.recoverQueue({threshold: `bogus`});
+      childTest.match(capturedRequest.args(), []);
+      childTest.equal(response.status, 400);
+      childTest.equal(
+        response.message,
+        `threshold must be a valid duration string (e.g. 5m, 1h).`,
+      );
+      childTest.end();
+    },
+  );
+});
+
 tap.test(`GET transaction by reference`, async t => {
   const mockLogger = createMockLogger();
   let thirdPartyRequest: BlnkRequest;

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -5,6 +5,7 @@ import {
   ValidateBulkCommitInflight,
   ValidateBulkVoidInflight,
   ValidateBulkTransactions,
+  ValidateRecoverQueue,
   ValidateRefundTransaction,
   ValidateUpdateTransactions,
 } from "../../../../src/blnk/utils/validators/transactionValidators";
@@ -14,6 +15,7 @@ import {
   BulkTransactions,
   CreateTransactions,
   MAX_BULK_INFLIGHT_ITEMS,
+  RecoverQueueRequest,
   RefundTransactionRequest,
   UpdateTransactionStatus,
 } from "../../../../src/types/transactions";
@@ -1016,6 +1018,43 @@ tap.test(`Issue #16 — bulkVoidInflight validation`, t => {
     tt.equal(
       ValidateBulkVoidInflight({transaction_ids: [``]}),
       `transaction_id is required at index 0.`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #17 — recoverQueue`, t => {
+  t.test(`allows valid threshold durations`, tt => {
+    const cases: RecoverQueueRequest[] = [
+      {threshold: `5m`},
+      {threshold: `1h`},
+      {threshold: `2h45m`},
+      {},
+    ];
+    for (const data of cases) {
+      tt.equal(ValidateRecoverQueue(data), null);
+    }
+    tt.end();
+  });
+
+  t.test(`rejects invalid threshold`, tt => {
+    tt.equal(
+      ValidateRecoverQueue({threshold: `bogus`}),
+      `threshold must be a valid duration string (e.g. 5m, 1h).`,
+    );
+    tt.equal(
+      ValidateRecoverQueue({threshold: ``}),
+      `threshold must be a valid duration string (e.g. 5m, 1h).`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects unknown fields`, tt => {
+    tt.equal(
+      ValidateRecoverQueue({threshold: `5m`, amount: 1} as RecoverQueueRequest),
+      `Invalid field: amount`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Add `Transactions.recoverQueue(options?)` calling `POST /transactions/recover`
- Optional `threshold` query param (Go duration string, e.g. `5m`, `1h`)
- Add `RecoverQueueRequest` / `RecoverQueueResponse` types
- Client-side validation for threshold duration format
- Unit tests (endpoint + validator) and README example
- Postman folder **TS SDK (#17)** in cloud collection (default + 24h threshold)

## Acceptance criteria
- [x] `Transactions.recoverQueue` → `/transactions/recover`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules (Go duration format)
- [x] Unit tests with mocked HTTP
- [x] README example

## Test plan
- [x] `npm run test:unit` (366 passing)
- [x] `npm run lint`
- [x] Postman: run **TS SDK (#17)** folder top to bottom against Core 0.14.5