### PR TITLE
feat(ledgers): add Ledgers.update (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ console.log("Ledger Created:", newLedger);
 
 This creates a new ledger for storing customer balances.
 
+### Updating a ledger name
+
+Rename an existing ledger without changing its ID or affecting balances and transactions:
+
+```typescript
+const updatedLedger = await Ledgers.update(
+  'ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc',
+  { name: 'Updated Customer Savings Account' },
+);
+console.log('Ledger Updated:', updatedLedger);
+```
+
 ---
 
 ## 5. Creating Balances

--- a/src/blnk/endpoints/ledgers.ts
+++ b/src/blnk/endpoints/ledgers.ts
@@ -1,8 +1,11 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
-import {CreateLedger, CreateLedgerResp} from "../../types/ledger";
+import {CreateLedger, CreateLedgerResp, UpdateLedger} from "../../types/ledger";
 import {HandleError} from "../utils/logger";
-import {ValidateCreateLedger} from "../utils/validators/ledgerValidators";
+import {
+  ValidateCreateLedger,
+  ValidateUpdateLedger,
+} from "../utils/validators/ledgerValidators";
 
 /**
  * Represents a class for managing ledger operations.
@@ -19,6 +22,10 @@ import {ValidateCreateLedger} from "../utils/validators/ledgerValidators";
  * @method getLedger - Retrieves a ledger entry by ID.
  * @param {string} id - The ID of the ledger entry to retrieve.
  * @returns {Promise<ApiResponse<CreateLedgerResp<T> | null>>} The response of the get operation.
+ * @method update - Updates an existing ledger's name.
+ * @param {string} id - The ID of the ledger to update.
+ * @param {UpdateLedger} data - The new ledger name.
+ * @returns {Promise<ApiResponse<CreateLedgerResp<T> | null>>} The response of the update operation.
  * @example
  * const ledgers = new Ledgers(requestFunction, loggerInstance, formatResponseFunction);
  * const newLedger = await ledgers.create({ name: 'New Ledger' });
@@ -78,5 +85,46 @@ export class Ledgers {
       undefined,
       `GET`,
     );
+  }
+
+  /**
+   * Updates an existing ledger's name.
+   *
+   * @see https://docs.blnkfinance.com/reference/update-ledger-name
+   *
+   * @example
+   * const response = await ledgers.update('ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc', {
+   *   name: 'Updated Customer Savings Account',
+   * });
+   */
+  async update<T extends Record<string, unknown>>(
+    id: string,
+    data: UpdateLedger,
+  ) {
+    try {
+      if (!id) {
+        return this.formatResponse(400, `ledger id is required`, null);
+      }
+
+      const error = ValidateUpdateLedger(data);
+      if (error) {
+        return this.formatResponse(400, error, null);
+      }
+
+      const response = await this.request<UpdateLedger, CreateLedgerResp<T>>(
+        `ledgers/${id}`,
+        data,
+        `PUT`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.update.name,
+      );
+    }
   }
 }

--- a/src/blnk/utils/validators/ledgerValidators.ts
+++ b/src/blnk/utils/validators/ledgerValidators.ts
@@ -1,4 +1,4 @@
-import {CreateLedger} from "../../../types/ledger";
+import {CreateLedger, UpdateLedger} from "../../../types/ledger";
 import {isValidMetaData} from "./ledgerBalance";
 
 export function ValidateCreateLedger<T extends Record<string, unknown>>(
@@ -15,6 +15,22 @@ export function ValidateCreateLedger<T extends Record<string, unknown>>(
   // Validate meta_data if provided
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
+  }
+
+  return null;
+}
+
+export function ValidateUpdateLedger(data: UpdateLedger): null | string {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type UpdateLedger`;
+  }
+
+  if (typeof data.name !== `string`) {
+    return `name field must be a valid string`;
+  }
+
+  if (data.name.trim() === ``) {
+    return `name field is required`;
   }
 
   return null;

--- a/src/types/ledger.ts
+++ b/src/types/ledger.ts
@@ -3,6 +3,11 @@ export interface CreateLedger<T extends Record<string, unknown>> {
   meta_data?: T;
 }
 
+/** Request body for `PUT /ledgers/{id}`. */
+export interface UpdateLedger {
+  name: string;
+}
+
 export interface CreateLedgerResp<T extends Record<string, unknown>> {
   ledger_id: string;
   name: string;

--- a/tests/unit/blnk/endpoints/ledgers.test.ts
+++ b/tests/unit/blnk/endpoints/ledgers.test.ts
@@ -7,7 +7,7 @@ import {
 import {BlnkRequest} from "../../../../src/types/general";
 import {Ledgers} from "../../../../src/blnk/endpoints/ledgers";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
-import {CreateLedger} from "../../../../src/types/ledger";
+import {CreateLedger, UpdateLedger} from "../../../../src/types/ledger";
 
 tap.test(`Ledger Tests`, async t => {
   const mockLogger = createMockLogger();
@@ -78,6 +78,54 @@ tap.test(`Ledger Tests`, async t => {
 
     tt.equal(response.status, 500, `Response is 500`);
     tt.equal(response.data, null);
+    tt.equal(response.message, `Network Error`);
+  });
+
+  t.test(`update calls PUT /ledgers/{id} (issue #6)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgers = new Ledgers(capturedRequest, mockLogger, FormatResponse);
+    const ledgerId = `ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc`;
+    const data: UpdateLedger = {name: `Updated Customer Savings Account`};
+
+    const response = await ledgers.update(ledgerId, data);
+
+    tt.match(capturedRequest.args(), [[`ledgers/${ledgerId}`, data, `PUT`]]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.name, data.name);
+  });
+
+  t.test(`update rejects empty ledger id (issue #6)`, async tt => {
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgers = new Ledgers(capturedRequest, mockLogger, FormatResponse);
+    const response = await ledgers.update(``, {name: `Updated Name`});
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `ledger id is required`);
+  });
+
+  t.test(`update rejects missing name (issue #6)`, async tt => {
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgers = new Ledgers(capturedRequest, mockLogger, FormatResponse);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await ledgers.update(`ldg_123`, {} as any);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.data, null);
+  });
+
+  t.test(`update handles thrown errors gracefully (issue #6)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, `Network Error`);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgers = new Ledgers(capturedRequest, mockLogger, FormatResponse);
+    const data: UpdateLedger = {name: `Updated Name`};
+
+    const response = await ledgers.update(`ldg_123`, data);
+
+    tt.match(capturedRequest.args(), [[`ledgers/ldg_123`, data, `PUT`]]);
+    tt.equal(response.status, 500);
     tt.equal(response.message, `Network Error`);
   });
 });

--- a/tests/unit/blnk/utils/ledgerValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerValidators.test.ts
@@ -1,0 +1,42 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  ValidateCreateLedger,
+  ValidateUpdateLedger,
+} from "../../../../src/blnk/utils/validators/ledgerValidators";
+import {CreateLedger, UpdateLedger} from "../../../../src/types/ledger";
+
+tap.test(`Issue #6 — ValidateUpdateLedger`, t => {
+  t.test(`accepts a valid name`, tt => {
+    const data: UpdateLedger = {name: `Updated Customer Savings Account`};
+    tt.equal(ValidateUpdateLedger(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects missing name`, tt => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tt.equal(
+      ValidateUpdateLedger({} as any),
+      `name field must be a valid string`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects empty name`, tt => {
+    tt.equal(ValidateUpdateLedger({name: ``}), `name field is required`);
+    tt.end();
+  });
+
+  t.test(`rejects whitespace-only name`, tt => {
+    tt.equal(ValidateUpdateLedger({name: `   `}), `name field is required`);
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`ValidateCreateLedger still accepts valid create payloads`, t => {
+  const data: CreateLedger<Record<string, never>> = {name: `My Ledger`};
+  t.equal(ValidateCreateLedger(data), null);
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `Ledgers.update(id, { name })` calling `PUT /ledgers/{id}` with `UpdateLedger` request type and `CreateLedgerResp` response
- Add `ValidateUpdateLedger` (required non-empty `name`, aligned with Core API rules)
- Unit tests for endpoint + validator; README example for renaming a ledger

## Test plan
- [x] `npm run test:unit` (388 tests)
- [x] `npm run lint`
- [ ] Postman: run **Setup**, then **TS SDK (#6)** folder in *Blnk SDK Issues — Local Core Tests (fixed)* against Core 0.14.5