### PR TITLE
feat(balances): add LedgerBalances.getLineage (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ const newBalance = await LedgerBalances.create({
 console.log("Balance Created:", newBalance);
 ```
 
+### Get balance lineage
+
+`LedgerBalances.getLineage` retrieves the provider breakdown for a balance with fund lineage enabled (`GET /balances/{balance_id}/lineage`):
+
+```typescript
+const response = await LedgerBalances.getLineage(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+);
+
+// response.data.balance_id
+// response.data.total_with_lineage
+// response.data.providers
+```
+
 ---
 
 ## 6. Recording Transactions

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -1,6 +1,7 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
+  BalanceLineageResponse,
   CreateLedgerBalance,
   CreateLedgerBalanceResp,
 } from "../../types/ledgerBalances";
@@ -92,6 +93,39 @@ export class LedgerBalances {
         this.logger,
         this.formatResponse,
         this.create.name,
+      );
+    }
+  }
+
+  /**
+   * Retrieves fund lineage for a balance (provider breakdown when lineage is enabled).
+   *
+   * @see https://docs.blnkfinance.com/reference/get-balance-lineage
+   *
+   * @example
+   * const response = await ledgerBalances.getLineage(
+   *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+   * );
+   */
+  async getLineage(balanceId: string) {
+    try {
+      if (!balanceId) {
+        return this.formatResponse(400, `balance id is required`, null);
+      }
+
+      const response = await this.request<undefined, BalanceLineageResponse>(
+        `balances/${balanceId}/lineage`,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getLineage.name,
       );
     }
   }

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -22,3 +22,28 @@ export interface CreateLedgerBalanceResp<T extends Record<string, unknown>> {
   created_at: string;
   meta_data?: T;
 }
+
+/** Per-provider fund breakdown in `BalanceLineageResponse.providers`. */
+export interface LineageProviderBreakdown {
+  provider: string;
+  /** Total received from this provider, in minor units. */
+  amount: string | number;
+  /** Still available from this provider, in minor units. */
+  available: string | number;
+  /** Already spent from this provider, in minor units. */
+  spent: string | number;
+  shadow_balance_id: string;
+}
+
+/**
+ * Response from `GET /balances/{balance_id}/lineage`.
+ *
+ * @see https://docs.blnkfinance.com/reference/get-balance-lineage
+ */
+export interface BalanceLineageResponse {
+  balance_id: string;
+  aggregate_balance_id: string;
+  /** Total lineage-tracked funds available, in minor units. */
+  total_with_lineage: string | number;
+  providers: LineageProviderBreakdown[];
+}

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -171,5 +171,40 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.equal(response.message, `meta_data must be a valid object if provided`);
     tt.end();
   });
+
+  t.test(`getLineage calls correct endpoint (issue #7)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    const response = await ledgerBalance.getLineage(balanceId);
+
+    tt.match(capturedRequest.args(), [
+      [`balances/${balanceId}/lineage`, undefined, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.end();
+  });
+
+  t.test(`getLineage rejects empty balance id (issue #7)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.getLineage(``);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `balance id is required`);
+    tt.end();
+  });
+
   t.end();
 });

--- a/tests/unit/types/balanceLineageResponse.test.ts
+++ b/tests/unit/types/balanceLineageResponse.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {BalanceLineageResponse} from "../../../src/types/ledgerBalances";
+
+const referenceResponse: BalanceLineageResponse = {
+  balance_id: `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`,
+  aggregate_balance_id: `bln_aggregate_shadow_balance_id`,
+  total_with_lineage: `7500`,
+  providers: [
+    {
+      provider: `stripe`,
+      amount: `10000`,
+      available: `7500`,
+      spent: `2500`,
+      shadow_balance_id: `bln_shadow_balance_id`,
+    },
+  ],
+};
+
+tap.test(`Issue #7 — BalanceLineageResponse API parity`, t => {
+  t.test(`accepts Core API reference response`, tt => {
+    tt.equal(
+      referenceResponse.balance_id,
+      `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`,
+    );
+    tt.equal(referenceResponse.providers.length, 1);
+    tt.equal(referenceResponse.providers[0].provider, `stripe`);
+    tt.end();
+  });
+
+  t.test(`accepts numeric minor-unit amounts`, tt => {
+    const numericResponse: BalanceLineageResponse = {
+      ...referenceResponse,
+      total_with_lineage: 7500,
+      providers: [
+        {
+          ...referenceResponse.providers[0],
+          amount: 10000,
+          available: 7500,
+          spent: 2500,
+        },
+      ],
+    };
+
+    tt.type(numericResponse.total_with_lineage, `number`);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `LedgerBalances.getLineage(balanceId)` calling `GET /balances/{balance_id}/lineage`
- Add `BalanceLineageResponse` and `LineageProviderBreakdown` types matching the Core API reference
- Client-side validation: rejects empty `balanceId` before the network call
- Unit tests for endpoint + response type parity; README usage example

## Test plan
- [x] `npm run test:unit` (400 tests)
- [x] `npm run lint`
- [ ] Postman: run **TS SDK (#7)** in *Blnk SDK Issues — Local Core Tests (fixed)* (self-setup pre-request if `lineage_balance_id` is empty)