### PR TITLE
Add LedgerBalances.getByIndicator (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ const newBalance = await LedgerBalances.create({
 console.log("Balance Created:", newBalance);
 ```
 
+### Get balance by indicator
+
+`LedgerBalances.getByIndicator` retrieves a balance by its indicator and currency (`GET /balances/indicator/{indicator}/currency/{currency}`):
+
+```typescript
+const response = await LedgerBalances.getByIndicator('@World', 'USD');
+
+// response.data.balance_id
+// response.data.indicator
+// response.data.currency
+```
+
 ### Get balance lineage
 
 `LedgerBalances.getLineage` retrieves the provider breakdown for a balance with fund lineage enabled (`GET /balances/{balance_id}/lineage`):

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -6,7 +6,10 @@ import {
   CreateLedgerBalanceResp,
 } from "../../types/ledgerBalances";
 import {HandleError} from "../utils/logger";
-import {ValidateCreateLedgerBalance} from "../utils/validators/ledgerBalance";
+import {
+  ValidateCreateLedgerBalance,
+  ValidateGetByIndicator,
+} from "../utils/validators/ledgerBalance";
 
 /**
  * Represents a class for managing ledger balances.
@@ -107,6 +110,44 @@ export class LedgerBalances {
    *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
    * );
    */
+  /**
+   * Retrieves a balance by its indicator and currency.
+   *
+   * @see https://docs.blnkfinance.com/reference/get-balance-by-indicator
+   *
+   * @example
+   * const response = await ledgerBalances.getByIndicator('@World', 'USD');
+   */
+  async getByIndicator<T extends Record<string, unknown>>(
+    indicator: string,
+    currency: string,
+  ) {
+    try {
+      const error = ValidateGetByIndicator(indicator, currency);
+      if (error) {
+        return this.formatResponse(400, error, null);
+      }
+
+      const response = await this.request<
+        undefined,
+        CreateLedgerBalanceResp<T>
+      >(
+        `balances/indicator/${encodeURIComponent(indicator)}/currency/${encodeURIComponent(currency)}`,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getByIndicator.name,
+      );
+    }
+  }
+
   async getLineage(balanceId: string) {
     try {
       if (!balanceId) {

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -101,16 +101,6 @@ export class LedgerBalances {
   }
 
   /**
-   * Retrieves fund lineage for a balance (provider breakdown when lineage is enabled).
-   *
-   * @see https://docs.blnkfinance.com/reference/get-balance-lineage
-   *
-   * @example
-   * const response = await ledgerBalances.getLineage(
-   *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
-   * );
-   */
-  /**
    * Retrieves a balance by its indicator and currency.
    *
    * @see https://docs.blnkfinance.com/reference/get-balance-by-indicator
@@ -148,6 +138,16 @@ export class LedgerBalances {
     }
   }
 
+  /**
+   * Retrieves fund lineage for a balance (provider breakdown when lineage is enabled).
+   *
+   * @see https://docs.blnkfinance.com/reference/get-balance-lineage
+   *
+   * @example
+   * const response = await ledgerBalances.getLineage(
+   *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+   * );
+   */
   async getLineage(balanceId: string) {
     try {
       if (!balanceId) {

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -35,3 +35,18 @@ export function ValidateCreateLedgerBalance<T extends Record<string, unknown>>(
 
 export const isValidMetaData = <T extends Record<string, unknown>>(meta: T) =>
   typeof meta === `object` && meta !== null;
+
+export function ValidateGetByIndicator(
+  indicator: string,
+  currency: string,
+): null | string {
+  if (!IsValidString(indicator) || indicator === ``) {
+    return `indicator is required`;
+  }
+
+  if (!IsValidString(currency) || currency === ``) {
+    return `currency is required`;
+  }
+
+  return null;
+}

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -20,6 +20,8 @@ export interface CreateLedgerBalanceResp<T extends Record<string, unknown>> {
   indicator: string;
   currency: string;
   created_at: string;
+  queued_credit_balance?: number;
+  queued_debit_balance?: number;
   meta_data?: T;
 }
 

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -206,5 +206,85 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.end();
   });
 
+  t.test(`getByIndicator calls correct endpoint (issue #8)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const indicator = `@World`;
+    const currency = `USD`;
+    const response = await ledgerBalance.getByIndicator(indicator, currency);
+
+    tt.match(capturedRequest.args(), [
+      [
+        `balances/indicator/${encodeURIComponent(indicator)}/currency/${encodeURIComponent(currency)}`,
+        undefined,
+        `GET`,
+      ],
+    ]);
+    tt.equal(response.status, 200);
+    tt.end();
+  });
+
+  t.test(
+    `getByIndicator path-escapes special characters (issue #8)`,
+    async tt => {
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const ledgerBalance = new LedgerBalances(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const indicator = `@user/name`;
+      const currency = `USD/EUR`;
+      await ledgerBalance.getByIndicator(indicator, currency);
+
+      tt.match(capturedRequest.args(), [
+        [
+          `balances/indicator/${encodeURIComponent(indicator)}/currency/${encodeURIComponent(currency)}`,
+          undefined,
+          `GET`,
+        ],
+      ]);
+      tt.end();
+    },
+  );
+
+  t.test(`getByIndicator rejects empty indicator (issue #8)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.getByIndicator(``, `USD`);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `indicator is required`);
+    tt.end();
+  });
+
+  t.test(`getByIndicator rejects empty currency (issue #8)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.getByIndicator(`@World`, ``);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `currency is required`);
+    tt.end();
+  });
+
   t.end();
 });

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -1,0 +1,22 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateGetByIndicator} from "../../../../src/blnk/utils/validators/ledgerBalance";
+
+tap.test(`Issue #8 — ValidateGetByIndicator`, t => {
+  t.test(`accepts valid indicator and currency`, tt => {
+    tt.equal(ValidateGetByIndicator(`@World`, `USD`), null);
+    tt.end();
+  });
+
+  t.test(`rejects empty indicator`, tt => {
+    tt.equal(ValidateGetByIndicator(``, `USD`), `indicator is required`);
+    tt.end();
+  });
+
+  t.test(`rejects empty currency`, tt => {
+    tt.equal(ValidateGetByIndicator(`@World`, ``), `currency is required`);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Adds `LedgerBalances.getByIndicator(indicator, currency)` calling `GET /balances/indicator/{indicator}/currency/{currency}`
- Validates empty indicator/currency before request (aligned with Go SDK)
- Path-encodes indicator and currency segments
- Extends balance response type with optional queued balance fields from API reference
- Unit tests for endpoint routing, validation, and path escaping
- README usage example

## Issue
Closes #8

## Test plan
- [x] `npm run test:unit` — 417 tests pass
- [x] `npm run lint` — clean
- [x] Postman: **TS SDK (#8)** folder in cloud collection — `GET /balances/indicator/@World/currency/USD`