### PR TITLE
Add LedgerBalances.updateIdentity (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ const response = await LedgerBalances.getByIndicator('@World', 'USD');
 // response.data.currency
 ```
 
+### Update balance identity
+
+`LedgerBalances.updateIdentity` links a balance to an identity (`PUT /balances/{id}/identity`):
+
+```typescript
+const response = await LedgerBalances.updateIdentity(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { identity_id: 'idt_3b63c8da-af29-4cc3-ad38-df17d87456e6' },
+);
+
+// response.data.message
+```
+
 ### Get balance lineage
 
 `LedgerBalances.getLineage` retrieves the provider breakdown for a balance with fund lineage enabled (`GET /balances/{balance_id}/lineage`):

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -4,11 +4,14 @@ import {
   BalanceLineageResponse,
   CreateLedgerBalance,
   CreateLedgerBalanceResp,
+  UpdateBalanceIdentity,
+  UpdateBalanceIdentityResponse,
 } from "../../types/ledgerBalances";
 import {HandleError} from "../utils/logger";
 import {
   ValidateCreateLedgerBalance,
   ValidateGetByIndicator,
+  ValidateUpdateBalanceIdentity,
 } from "../utils/validators/ledgerBalance";
 
 /**
@@ -134,6 +137,44 @@ export class LedgerBalances {
         this.logger,
         this.formatResponse,
         this.getByIndicator.name,
+      );
+    }
+  }
+
+  /**
+   * Updates the identity linked to a balance.
+   *
+   * @see https://docs.blnkfinance.com/reference/update-balance-identity
+   *
+   * @example
+   * const response = await ledgerBalances.updateIdentity(
+   *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+   *   { identity_id: 'idt_3b63c8da-af29-4cc3-ad38-df17d87456e6' },
+   * );
+   */
+  async updateIdentity(balanceId: string, data: UpdateBalanceIdentity) {
+    try {
+      if (!balanceId) {
+        return this.formatResponse(400, `balance id is required`, null);
+      }
+
+      const error = ValidateUpdateBalanceIdentity(data);
+      if (error) {
+        return this.formatResponse(400, error, null);
+      }
+
+      const response = await this.request<
+        UpdateBalanceIdentity,
+        UpdateBalanceIdentityResponse
+      >(`balances/${balanceId}/identity`, data, `PUT`);
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.updateIdentity.name,
       );
     }
   }

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -1,4 +1,7 @@
-import {CreateLedgerBalance} from "../../../types/ledgerBalances";
+import {
+  CreateLedgerBalance,
+  UpdateBalanceIdentity,
+} from "../../../types/ledgerBalances";
 import {IsValidString} from "../stringUtils";
 
 export function ValidateCreateLedgerBalance<T extends Record<string, unknown>>(
@@ -46,6 +49,20 @@ export function ValidateGetByIndicator(
 
   if (!IsValidString(currency) || currency === ``) {
     return `currency is required`;
+  }
+
+  return null;
+}
+
+export function ValidateUpdateBalanceIdentity(
+  data: UpdateBalanceIdentity,
+): null | string {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type UpdateBalanceIdentity`;
+  }
+
+  if (!IsValidString(data.identity_id) || data.identity_id === ``) {
+    return `identity_id is required`;
   }
 
   return null;

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -49,3 +49,13 @@ export interface BalanceLineageResponse {
   total_with_lineage: string | number;
   providers: LineageProviderBreakdown[];
 }
+
+/** Request body for `PUT /balances/{id}/identity`. */
+export interface UpdateBalanceIdentity {
+  identity_id: string;
+}
+
+/** Response from `PUT /balances/{id}/identity`. */
+export interface UpdateBalanceIdentityResponse {
+  message: string;
+}

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -286,5 +286,62 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.end();
   });
 
+  t.test(
+    `updateIdentity calls PUT /balances/{id}/identity (issue #9)`,
+    async tt => {
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const ledgerBalance = new LedgerBalances(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+      const data = {identity_id: `idt_3b63c8da-af29-4cc3-ad38-df17d87456e6`};
+      const response = await ledgerBalance.updateIdentity(balanceId, data);
+
+      tt.match(capturedRequest.args(), [
+        [`balances/${balanceId}/identity`, data, `PUT`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.end();
+    },
+  );
+
+  t.test(`updateIdentity rejects empty balance id (issue #9)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.updateIdentity(``, {
+      identity_id: `idt_3b63c8da-af29-4cc3-ad38-df17d87456e6`,
+    });
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `balance id is required`);
+    tt.end();
+  });
+
+  t.test(`updateIdentity rejects missing identity_id (issue #9)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await ledgerBalance.updateIdentity(`bln_123`, {} as any);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `identity_id is required`);
+    tt.end();
+  });
+
   t.end();
 });

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
-import {ValidateGetByIndicator} from "../../../../src/blnk/utils/validators/ledgerBalance";
+import {
+  ValidateGetByIndicator,
+  ValidateUpdateBalanceIdentity,
+} from "../../../../src/blnk/utils/validators/ledgerBalance";
 
 tap.test(`Issue #8 — ValidateGetByIndicator`, t => {
   t.test(`accepts valid indicator and currency`, tt => {
@@ -15,6 +18,37 @@ tap.test(`Issue #8 — ValidateGetByIndicator`, t => {
 
   t.test(`rejects empty currency`, tt => {
     tt.equal(ValidateGetByIndicator(`@World`, ``), `currency is required`);
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #9 — ValidateUpdateBalanceIdentity`, t => {
+  t.test(`accepts valid identity_id`, tt => {
+    tt.equal(
+      ValidateUpdateBalanceIdentity({
+        identity_id: `idt_3b63c8da-af29-4cc3-ad38-df17d87456e6`,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects missing identity_id`, tt => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tt.equal(
+      ValidateUpdateBalanceIdentity({} as any),
+      `identity_id is required`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects empty identity_id`, tt => {
+    tt.equal(
+      ValidateUpdateBalanceIdentity({identity_id: ``}),
+      `identity_id is required`,
+    );
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Adds `LedgerBalances.updateIdentity(balanceId, { identity_id })` calling `PUT /balances/{id}/identity`
- Introduces `UpdateBalanceIdentity` and `UpdateBalanceIdentityResponse` types aligned with the [Core API reference](https://docs.blnkfinance.com/reference/update-balance-identity)
- Validates empty `balanceId` and missing/empty `identity_id` before request (aligned with Go SDK)
- Unit tests for endpoint routing and validation; README example added

## Issue
Closes #9

## Test plan
- [x] `npm run test:unit` — 432 tests pass
- [x] `npm run lint` — clean
- [x] Postman: **TS SDK (#9)** folder — PUT update identity + GET verify