### PR TITLE
Add LedgerBalances.createSnapshot (closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ const response = await LedgerBalances.updateIdentity(
 // response.data.message
 ```
 
+### Create balance snapshots
+
+`LedgerBalances.createSnapshot` triggers daily balance snapshots in batches (`POST /balances-snapshots`). Omit `batch_size` or pass zero to use the server default (1000):
+
+```typescript
+const response = await LedgerBalances.createSnapshot({ batch_size: 500 });
+
+// response.data.message
+```
+
 ### Get balance lineage
 
 `LedgerBalances.getLineage` retrieves the provider breakdown for a balance with fund lineage enabled (`GET /balances/{balance_id}/lineage`):

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -2,6 +2,8 @@ import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
   BalanceLineageResponse,
+  CreateBalanceSnapshotRequest,
+  CreateBalanceSnapshotResponse,
   CreateLedgerBalance,
   CreateLedgerBalanceResp,
   UpdateBalanceIdentity,
@@ -9,6 +11,7 @@ import {
 } from "../../types/ledgerBalances";
 import {HandleError} from "../utils/logger";
 import {
+  ValidateCreateBalanceSnapshot,
   ValidateCreateLedgerBalance,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
@@ -175,6 +178,45 @@ export class LedgerBalances {
         this.logger,
         this.formatResponse,
         this.updateIdentity.name,
+      );
+    }
+  }
+
+  /**
+   * Triggers daily balance snapshots in batches.
+   *
+   * @see https://docs.blnkfinance.com/reference/balances-snapshots
+   *
+   * @example
+   * const response = await ledgerBalances.createSnapshot({ batch_size: 500 });
+   * // response.data.message
+   */
+  async createSnapshot(options?: CreateBalanceSnapshotRequest) {
+    try {
+      if (options !== undefined) {
+        const error = ValidateCreateBalanceSnapshot(options);
+        if (error) {
+          return this.formatResponse(400, error, null);
+        }
+      }
+
+      const endpoint =
+        options?.batch_size && options.batch_size > 0
+          ? `balances-snapshots?batch_size=${options.batch_size}`
+          : `balances-snapshots`;
+
+      const response = await this.request<
+        undefined,
+        CreateBalanceSnapshotResponse
+      >(endpoint, undefined, `POST`);
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.createSnapshot.name,
       );
     }
   }

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -1,5 +1,6 @@
 import {
   CreateLedgerBalance,
+  CreateBalanceSnapshotRequest,
   UpdateBalanceIdentity,
 } from "../../../types/ledgerBalances";
 import {IsValidString} from "../stringUtils";
@@ -63,6 +64,24 @@ export function ValidateUpdateBalanceIdentity(
 
   if (!IsValidString(data.identity_id) || data.identity_id === ``) {
     return `identity_id is required`;
+  }
+
+  return null;
+}
+
+export function ValidateCreateBalanceSnapshot(
+  data?: CreateBalanceSnapshotRequest,
+): null | string {
+  if (data === undefined) {
+    return null;
+  }
+
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type CreateBalanceSnapshotRequest`;
+  }
+
+  if (data.batch_size !== undefined && data.batch_size < 0) {
+    return `batch_size must be positive`;
   }
 
   return null;

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -59,3 +59,14 @@ export interface UpdateBalanceIdentity {
 export interface UpdateBalanceIdentityResponse {
   message: string;
 }
+
+/** Optional request for `POST /balances-snapshots`. */
+export interface CreateBalanceSnapshotRequest {
+  /** Balances processed per batch. Omit or zero uses the server default (1000). */
+  batch_size?: number;
+}
+
+/** Response from `POST /balances-snapshots`. */
+export interface CreateBalanceSnapshotResponse {
+  message: string;
+}

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -343,5 +343,79 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.end();
   });
 
+  t.test(
+    `createSnapshot calls POST /balances-snapshots (issue #10)`,
+    async tt => {
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const ledgerBalance = new LedgerBalances(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      const response = await ledgerBalance.createSnapshot();
+
+      tt.match(capturedRequest.args(), [
+        [`balances-snapshots`, undefined, `POST`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `createSnapshot forwards batch_size query param (issue #10)`,
+    async tt => {
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const ledgerBalance = new LedgerBalances(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      await ledgerBalance.createSnapshot({batch_size: 500});
+
+      tt.match(capturedRequest.args(), [
+        [`balances-snapshots?batch_size=500`, undefined, `POST`],
+      ]);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `createSnapshot omits query when batch_size is zero (issue #10)`,
+    async tt => {
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const ledgerBalance = new LedgerBalances(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+      await ledgerBalance.createSnapshot({batch_size: 0});
+
+      tt.match(capturedRequest.args(), [
+        [`balances-snapshots`, undefined, `POST`],
+      ]);
+      tt.end();
+    },
+  );
+
+  t.test(`createSnapshot rejects negative batch_size (issue #10)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.createSnapshot({batch_size: -1});
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `batch_size must be positive`);
+    tt.end();
+  });
+
   t.end();
 });

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
 import {
+  ValidateCreateBalanceSnapshot,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
 } from "../../../../src/blnk/utils/validators/ledgerBalance";
@@ -48,6 +49,33 @@ tap.test(`Issue #9 — ValidateUpdateBalanceIdentity`, t => {
     tt.equal(
       ValidateUpdateBalanceIdentity({identity_id: ``}),
       `identity_id is required`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #10 — ValidateCreateBalanceSnapshot`, t => {
+  t.test(`accepts empty options`, tt => {
+    tt.equal(ValidateCreateBalanceSnapshot(undefined), null);
+    tt.end();
+  });
+
+  t.test(`accepts positive batch_size`, tt => {
+    tt.equal(ValidateCreateBalanceSnapshot({batch_size: 500}), null);
+    tt.end();
+  });
+
+  t.test(`accepts zero batch_size`, tt => {
+    tt.equal(ValidateCreateBalanceSnapshot({batch_size: 0}), null);
+    tt.end();
+  });
+
+  t.test(`rejects negative batch_size`, tt => {
+    tt.equal(
+      ValidateCreateBalanceSnapshot({batch_size: -1}),
+      `batch_size must be positive`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Adds `LedgerBalances.createSnapshot(options?)` calling `POST /balances-snapshots`
- Optional `batch_size` query param when value is positive; omitted for default server batch (1000)
- Introduces `CreateBalanceSnapshotRequest` and `CreateBalanceSnapshotResponse` types aligned with the [Core API reference](https://docs.blnkfinance.com/reference/balances-snapshots)
- Validates negative `batch_size` before request (aligned with Go SDK)
- Unit tests for default endpoint, batch_size forwarding, zero batch_size, and validation; README example added

## Issue
Closes #10

## Test plan
- [x] `npm run test:unit` — 448 tests pass
- [x] `npm run lint` — clean
- [x] Postman: **TS SDK (#10)** folder — default POST + batch_size=100