### PR TITLE
Add LedgerBalances.getAt (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ const response = await LedgerBalances.createSnapshot({ batch_size: 500 });
 // response.data.message
 ```
 
+### Get historical balance
+
+`LedgerBalances.getAt` retrieves a balance at a specific timestamp (`GET /balances/{balance_id}/at`):
+
+```typescript
+const response = await LedgerBalances.getAt(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { timestamp: '2025-02-24T08:55:26Z', from_source: true },
+);
+
+// response.data.balance.balance_id
+// response.data.balance.balance
+// response.data.timestamp
+```
+
 ### Get balance lineage
 
 `LedgerBalances.getLineage` retrieves the provider breakdown for a balance with fund lineage enabled (`GET /balances/{balance_id}/lineage`):

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -6,6 +6,8 @@ import {
   CreateBalanceSnapshotResponse,
   CreateLedgerBalance,
   CreateLedgerBalanceResp,
+  GetBalanceAtRequest,
+  GetBalanceAtResponse,
   UpdateBalanceIdentity,
   UpdateBalanceIdentityResponse,
 } from "../../types/ledgerBalances";
@@ -13,6 +15,7 @@ import {HandleError} from "../utils/logger";
 import {
   ValidateCreateBalanceSnapshot,
   ValidateCreateLedgerBalance,
+  ValidateGetBalanceAt,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
 } from "../utils/validators/ledgerBalance";
@@ -217,6 +220,50 @@ export class LedgerBalances {
         this.logger,
         this.formatResponse,
         this.createSnapshot.name,
+      );
+    }
+  }
+
+  /**
+   * Retrieves a balance's state at a specific point in time.
+   *
+   * @see https://docs.blnkfinance.com/reference/historical-balances
+   *
+   * @example
+   * const response = await ledgerBalances.getAt(
+   *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+   *   { timestamp: '2025-02-24T08:55:26Z', from_source: true },
+   * );
+   */
+  async getAt(balanceId: string, options: GetBalanceAtRequest) {
+    try {
+      if (!balanceId) {
+        return this.formatResponse(400, `balance id is required`, null);
+      }
+
+      const error = ValidateGetBalanceAt(options);
+      if (error) {
+        return this.formatResponse(400, error, null);
+      }
+
+      let endpoint = `balances/${balanceId}/at?timestamp=${encodeURIComponent(options.timestamp)}`;
+      if (options.from_source) {
+        endpoint += `&from_source=true`;
+      }
+
+      const response = await this.request<undefined, GetBalanceAtResponse>(
+        endpoint,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getAt.name,
       );
     }
   }

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -1,6 +1,7 @@
 import {
-  CreateLedgerBalance,
   CreateBalanceSnapshotRequest,
+  CreateLedgerBalance,
+  GetBalanceAtRequest,
   UpdateBalanceIdentity,
 } from "../../../types/ledgerBalances";
 import {IsValidString} from "../stringUtils";
@@ -82,6 +83,18 @@ export function ValidateCreateBalanceSnapshot(
 
   if (data.batch_size !== undefined && data.batch_size < 0) {
     return `batch_size must be positive`;
+  }
+
+  return null;
+}
+
+export function ValidateGetBalanceAt(data: GetBalanceAtRequest): null | string {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type GetBalanceAtRequest`;
+  }
+
+  if (!IsValidString(data.timestamp) || data.timestamp === ``) {
+    return `timestamp is required`;
   }
 
   return null;

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -70,3 +70,27 @@ export interface CreateBalanceSnapshotRequest {
 export interface CreateBalanceSnapshotResponse {
   message: string;
 }
+
+/** Balance amounts in `GetBalanceAtResponse.balance`. */
+export interface HistoricalBalanceDetails {
+  balance: string | number;
+  balance_id: string;
+  credit_balance: string | number;
+  currency: string;
+  debit_balance: string | number;
+}
+
+/** Options for `GET /balances/{balance_id}/at`. */
+export interface GetBalanceAtRequest {
+  /** ISO 8601 timestamp (RFC3339), e.g. `2025-02-24T08:55:26Z`. */
+  timestamp: string;
+  /** Reconstruct from transactions instead of snapshots when true. */
+  from_source?: boolean;
+}
+
+/** Response from `GET /balances/{balance_id}/at`. */
+export interface GetBalanceAtResponse {
+  balance: HistoricalBalanceDetails;
+  timestamp: string;
+  from_source: boolean;
+}

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -417,5 +417,83 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.end();
   });
 
+  t.test(`getAt calls GET /balances/{id}/at (issue #11)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    const timestamp = `2025-02-24T08:55:26Z`;
+    await ledgerBalance.getAt(balanceId, {timestamp});
+
+    tt.match(capturedRequest.args(), [
+      [
+        `balances/${balanceId}/at?timestamp=${encodeURIComponent(timestamp)}`,
+        undefined,
+        `GET`,
+      ],
+    ]);
+    tt.end();
+  });
+
+  t.test(`getAt forwards from_source query param (issue #11)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    const timestamp = `2025-02-24T08:55:26Z`;
+    await ledgerBalance.getAt(balanceId, {timestamp, from_source: true});
+
+    tt.match(capturedRequest.args(), [
+      [
+        `balances/${balanceId}/at?timestamp=${encodeURIComponent(timestamp)}&from_source=true`,
+        undefined,
+        `GET`,
+      ],
+    ]);
+    tt.end();
+  });
+
+  t.test(`getAt rejects empty balance id (issue #11)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.getAt(``, {
+      timestamp: `2025-02-24T08:55:26Z`,
+    });
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `balance id is required`);
+    tt.end();
+  });
+
+  t.test(`getAt rejects empty timestamp (issue #11)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const response = await ledgerBalance.getAt(`bln_123`, {timestamp: ``});
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `timestamp is required`);
+    tt.end();
+  });
+
   t.end();
 });

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -2,6 +2,7 @@
 import tap from "tap";
 import {
   ValidateCreateBalanceSnapshot,
+  ValidateGetBalanceAt,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
 } from "../../../../src/blnk/utils/validators/ledgerBalance";
@@ -77,6 +78,31 @@ tap.test(`Issue #10 — ValidateCreateBalanceSnapshot`, t => {
       ValidateCreateBalanceSnapshot({batch_size: -1}),
       `batch_size must be positive`,
     );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #11 — ValidateGetBalanceAt`, t => {
+  t.test(`accepts valid timestamp`, tt => {
+    tt.equal(ValidateGetBalanceAt({timestamp: `2025-02-24T08:55:26Z`}), null);
+    tt.end();
+  });
+
+  t.test(`accepts from_source flag`, tt => {
+    tt.equal(
+      ValidateGetBalanceAt({
+        timestamp: `2025-02-24T08:55:26Z`,
+        from_source: true,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects empty timestamp`, tt => {
+    tt.equal(ValidateGetBalanceAt({timestamp: ``}), `timestamp is required`);
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Adds `LedgerBalances.getAt(balanceId, { timestamp, from_source? })` calling `GET /balances/{balance_id}/at`
- Introduces `GetBalanceAtRequest`, `GetBalanceAtResponse`, and `HistoricalBalanceDetails` types aligned with the [Core API reference](https://docs.blnkfinance.com/reference/historical-balances)
- Validates empty `balanceId` and missing/empty `timestamp` before request (aligned with Go SDK)
- Forwards optional `from_source=true` query param when requested
- Unit tests for endpoint routing, query params, validation; README example added

## Issue
Closes #11

## Test plan
- [x] `npm run test:unit` — 464 tests pass
- [x] `npm run lint` — clean
- [x] Postman: **TS SDK (#11)** folder — historical GET + from_source GET