### PR TITLE
Add track_fund_lineage and allocation_strategy to balance create (closes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ const newBalance = await LedgerBalances.create({
 console.log("Balance Created:", newBalance);
 ```
 
+With fund lineage tracking enabled (requires `identity_id`):
+
+```typescript
+const lineageBalance = await LedgerBalances.create({
+  ledger_id: "ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc",
+  identity_id: "idt_3b63c8da-af29-4cc3-ad38-df17d87456e6",
+  currency: "USD",
+  track_fund_lineage: true,
+  allocation_strategy: "FIFO", // FIFO | LIFO | PROPORTIONAL
+});
+```
+
 ### Get balance by indicator
 
 `LedgerBalances.getByIndicator` retrieves a balance by its indicator and currency (`GET /balances/indicator/{indicator}/currency/{currency}`):

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -1,10 +1,17 @@
 import {
+  AllocationStrategy,
   CreateBalanceSnapshotRequest,
   CreateLedgerBalance,
   GetBalanceAtRequest,
   UpdateBalanceIdentity,
 } from "../../../types/ledgerBalances";
 import {IsValidString} from "../stringUtils";
+
+const ALLOCATION_STRATEGIES: AllocationStrategy[] = [
+  `FIFO`,
+  `LIFO`,
+  `PROPORTIONAL`,
+];
 
 export function ValidateCreateLedgerBalance<T extends Record<string, unknown>>(
   data: CreateLedgerBalance<T>,
@@ -32,6 +39,20 @@ export function ValidateCreateLedgerBalance<T extends Record<string, unknown>>(
   // Validate meta_data if provided
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
+  }
+
+  if (
+    data.track_fund_lineage !== undefined &&
+    typeof data.track_fund_lineage !== `boolean`
+  ) {
+    return `track_fund_lineage must be a boolean if provided`;
+  }
+
+  if (
+    data.allocation_strategy !== undefined &&
+    !ALLOCATION_STRATEGIES.includes(data.allocation_strategy)
+  ) {
+    return `allocation_strategy must be one of FIFO, LIFO, or PROPORTIONAL`;
   }
 
   // If all validations pass, return null

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -1,7 +1,14 @@
+/** Fund allocation strategy when `track_fund_lineage` is enabled. */
+export type AllocationStrategy = `FIFO` | `LIFO` | `PROPORTIONAL`;
+
 export interface CreateLedgerBalance<T extends Record<string, unknown>> {
   ledger_id: string;
   identity_id?: string;
   currency: string;
+  /** Enables fund lineage tracking. Requires `identity_id`. */
+  track_fund_lineage?: boolean;
+  /** How tagged provider funds are allocated when spending. Defaults to `FIFO`. */
+  allocation_strategy?: AllocationStrategy;
   meta_data?: T;
 }
 
@@ -22,6 +29,8 @@ export interface CreateLedgerBalanceResp<T extends Record<string, unknown>> {
   created_at: string;
   queued_credit_balance?: number;
   queued_debit_balance?: number;
+  track_fund_lineage?: boolean;
+  allocation_strategy?: AllocationStrategy;
   meta_data?: T;
 }
 

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -143,6 +143,72 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.equal(response.message, `Network Error`);
     tt.end();
   });
+  t.test(
+    `create forwards track_fund_lineage and allocation_strategy (issue #47)`,
+    async tt => {
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const ledgerBalance = new LedgerBalances(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: CreateLedgerBalance<Record<string, unknown>> = {
+        ledger_id: ledgerId,
+        identity_id: `idt_3b63c8da-af29-4cc3-ad38-df17d87456e6`,
+        currency: `USD`,
+        track_fund_lineage: true,
+        allocation_strategy: `PROPORTIONAL`,
+      };
+
+      const response = await ledgerBalance.create(data);
+
+      tt.match(capturedRequest.args(), [
+        [
+          `balances`,
+          {
+            ledger_id: ledgerId,
+            identity_id: `idt_3b63c8da-af29-4cc3-ad38-df17d87456e6`,
+            currency: `USD`,
+            track_fund_lineage: true,
+            allocation_strategy: `PROPORTIONAL`,
+          },
+          `POST`,
+        ],
+      ]);
+      tt.equal(response.status, 201);
+      tt.end();
+    },
+  );
+
+  t.test(`create rejects invalid allocation_strategy (issue #47)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = {
+      ledger_id: ledgerId,
+      currency: `USD`,
+      allocation_strategy: `INVALID`,
+    };
+
+    const response = await ledgerBalance.create(data);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(
+      response.message,
+      `allocation_strategy must be one of FIFO, LIFO, or PROPORTIONAL`,
+    );
+    tt.end();
+  });
+
   t.test(`it should handle meta_data if it is not an object`, async tt => {
     const thirdPartyRequest = createMockBlnkRequest(true);
     const capturedRequest = tt.captureFn(thirdPartyRequest);

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -2,6 +2,7 @@
 import tap from "tap";
 import {
   ValidateCreateBalanceSnapshot,
+  ValidateCreateLedgerBalance,
   ValidateGetBalanceAt,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
@@ -77,6 +78,61 @@ tap.test(`Issue #10 — ValidateCreateBalanceSnapshot`, t => {
     tt.equal(
       ValidateCreateBalanceSnapshot({batch_size: -1}),
       `batch_size must be positive`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #47 — ValidateCreateLedgerBalance lineage fields`, t => {
+  t.test(`accepts track_fund_lineage and allocation_strategy`, tt => {
+    tt.equal(
+      ValidateCreateLedgerBalance({
+        ledger_id: `ldg_123`,
+        currency: `USD`,
+        identity_id: `idt_123`,
+        track_fund_lineage: true,
+        allocation_strategy: `LIFO`,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`accepts request without lineage fields`, tt => {
+    tt.equal(
+      ValidateCreateLedgerBalance({
+        ledger_id: `ldg_123`,
+        currency: `USD`,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects non-boolean track_fund_lineage`, tt => {
+    tt.equal(
+      ValidateCreateLedgerBalance({
+        ledger_id: `ldg_123`,
+        currency: `USD`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        track_fund_lineage: `true` as any,
+      }),
+      `track_fund_lineage must be a boolean if provided`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid allocation_strategy`, tt => {
+    tt.equal(
+      ValidateCreateLedgerBalance({
+        ledger_id: `ldg_123`,
+        currency: `USD`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        allocation_strategy: `INVALID` as any,
+      }),
+      `allocation_strategy must be one of FIFO, LIFO, or PROPORTIONAL`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Extend `CreateLedgerBalance` with optional `track_fund_lineage` and `allocation_strategy` (`FIFO` | `LIFO` | `PROPORTIONAL`) aligned with the [Core create-balance API](https://docs.blnkfinance.com/reference/create-balance)
- Add matching fields on `CreateLedgerBalanceResp`
- Client-side validation: `track_fund_lineage` must be boolean; `allocation_strategy` must be one of the supported values
- Unit tests for endpoint serialization and validator coverage; README usage example

## Test plan
- [x] `npm run test:unit` — 476 pass
- [x] `npm run lint` — clean
- [x] Manual Core 0.14.5 curl — `POST /balances` returns `track_fund_lineage` + `allocation_strategy` in response
- [ ] Postman **TS SDK (#47)** folder — run against local Core

Closes #47