### PR TITLE
Add from_source query param to LedgerBalances.get (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ const lineageBalance = await LedgerBalances.create({
 });
 ```
 
+### Get balance
+
+`LedgerBalances.get` retrieves a balance by ID (`GET /balances/{balance_id}`). Pass `{ from_source: true }` to reconstruct the balance from transactions instead of snapshots:
+
+```typescript
+const response = await LedgerBalances.get(
+  'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+  { from_source: true },
+);
+
+// response.data.balance_id
+// response.data.balance
+```
+
 ### Get balance by indicator
 
 `LedgerBalances.getByIndicator` retrieves a balance by its indicator and currency (`GET /balances/indicator/{indicator}/currency/{currency}`):

--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -8,6 +8,7 @@ import {
   CreateLedgerBalanceResp,
   GetBalanceAtRequest,
   GetBalanceAtResponse,
+  GetBalanceRequest,
   UpdateBalanceIdentity,
   UpdateBalanceIdentityResponse,
 } from "../../types/ledgerBalances";
@@ -15,6 +16,7 @@ import {HandleError} from "../utils/logger";
 import {
   ValidateCreateBalanceSnapshot,
   ValidateCreateLedgerBalance,
+  ValidateGetBalance,
   ValidateGetBalanceAt,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
@@ -94,9 +96,41 @@ export class LedgerBalances {
     }
   }
 
-  async get(id: string) {
+  /**
+   * Retrieves a balance by its ID.
+   *
+   * Pass `{ from_source: true }` to reconstruct the balance from transactions
+   * instead of snapshots (`GET /balances/{balance_id}?from_source=true`).
+   *
+   * @see https://docs.blnkfinance.com/reference/balance-from-source
+   *
+   * @example
+   * const response = await ledgerBalances.get(
+   *   'bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f',
+   *   { from_source: true },
+   * );
+   */
+  async get<T extends Record<string, unknown>>(
+    id: string,
+    options?: GetBalanceRequest,
+  ) {
     try {
-      const response = await this.request(`balances/${id}`, undefined, `GET`);
+      if (options !== undefined) {
+        const error = ValidateGetBalance(options);
+        if (error) {
+          return this.formatResponse(400, error, null);
+        }
+      }
+
+      let endpoint = `balances/${id}`;
+      if (options?.from_source) {
+        endpoint += `?from_source=true`;
+      }
+
+      const response = await this.request<
+        undefined,
+        CreateLedgerBalanceResp<T>
+      >(endpoint, undefined, `GET`);
 
       return response;
     } catch (error: unknown) {
@@ -104,7 +138,7 @@ export class LedgerBalances {
         error,
         this.logger,
         this.formatResponse,
-        this.create.name,
+        this.get.name,
       );
     }
   }

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -3,6 +3,7 @@ import {
   CreateBalanceSnapshotRequest,
   CreateLedgerBalance,
   GetBalanceAtRequest,
+  GetBalanceRequest,
   UpdateBalanceIdentity,
 } from "../../../types/ledgerBalances";
 import {IsValidString} from "../stringUtils";
@@ -104,6 +105,18 @@ export function ValidateCreateBalanceSnapshot(
 
   if (data.batch_size !== undefined && data.batch_size < 0) {
     return `batch_size must be positive`;
+  }
+
+  return null;
+}
+
+export function ValidateGetBalance(data: GetBalanceRequest): null | string {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type GetBalanceRequest`;
+  }
+
+  if (data.from_source !== undefined && typeof data.from_source !== `boolean`) {
+    return `from_source must be a boolean if provided`;
   }
 
   return null;

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -89,6 +89,12 @@ export interface HistoricalBalanceDetails {
   debit_balance: string | number;
 }
 
+/** Options for `GET /balances/{balance_id}`. */
+export interface GetBalanceRequest {
+  /** Reconstruct balance from transactions instead of snapshots when true. */
+  from_source?: boolean;
+}
+
 /** Options for `GET /balances/{balance_id}/at`. */
 export interface GetBalanceAtRequest {
   /** ISO 8601 timestamp (RFC3339), e.g. `2025-02-24T08:55:26Z`. */

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -483,6 +483,59 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.end();
   });
 
+  t.test(`get calls GET /balances/{id} (issue #48)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    await ledgerBalance.get(balanceId);
+
+    tt.match(capturedRequest.args(), [
+      [`balances/${balanceId}`, undefined, `GET`],
+    ]);
+    tt.end();
+  });
+
+  t.test(`get forwards from_source query param (issue #48)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    await ledgerBalance.get(balanceId, {from_source: true});
+
+    tt.match(capturedRequest.args(), [
+      [`balances/${balanceId}?from_source=true`, undefined, `GET`],
+    ]);
+    tt.end();
+  });
+
+  t.test(`get rejects invalid from_source (issue #48)`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await ledgerBalance.get(`bln_123`, {
+      from_source: `true`,
+    } as any);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `from_source must be a boolean if provided`);
+    tt.end();
+  });
+
   t.test(`getAt calls GET /balances/{id}/at (issue #11)`, async tt => {
     const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
     const capturedRequest = tt.captureFn(thirdPartyRequest);

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -3,6 +3,7 @@ import tap from "tap";
 import {
   ValidateCreateBalanceSnapshot,
   ValidateCreateLedgerBalance,
+  ValidateGetBalance,
   ValidateGetBalanceAt,
   ValidateGetByIndicator,
   ValidateUpdateBalanceIdentity,
@@ -133,6 +134,29 @@ tap.test(`Issue #47 — ValidateCreateLedgerBalance lineage fields`, t => {
         allocation_strategy: `INVALID` as any,
       }),
       `allocation_strategy must be one of FIFO, LIFO, or PROPORTIONAL`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});
+
+tap.test(`Issue #48 — ValidateGetBalance`, t => {
+  t.test(`accepts from_source flag`, tt => {
+    tt.equal(ValidateGetBalance({from_source: true}), null);
+    tt.end();
+  });
+
+  t.test(`accepts empty options object`, tt => {
+    tt.equal(ValidateGetBalance({}), null);
+    tt.end();
+  });
+
+  t.test(`rejects non-boolean from_source`, tt => {
+    tt.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ValidateGetBalance({from_source: `true` as any}),
+      `from_source must be a boolean if provided`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Extend `LedgerBalances.get(id, options?)` with optional `{ from_source?: boolean }` aligned with the [balance-from-source API reference](https://docs.blnkfinance.com/reference/balance-from-source)
- Appends `?from_source=true` to `GET /balances/{balance_id}` when requested
- Adds `GetBalanceRequest` type and client-side validation for boolean `from_source`
- Unit tests for default GET, from_source query forwarding, and validation rejection
- README usage example

## Test plan
- [x] `npm run test:unit` — 488 pass
- [x] `npm run lint` — clean
- [x] Manual Core 0.14.5 curl — `GET /balances/{id}?from_source=true` returns 200
- [ ] Postman **TS SDK (#48)** folder — run against local Core

Closes #48