### PR TITLE
Add optional identity_id and ISO dob to Identity.create (closes #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,36 @@ console.log('Ledger Updated:', updatedLedger);
 
 ---
 
-## 5. Creating Balances
+## 5. Creating Identities
+
+Register customers or organizations before linking them to balances. Pass an optional caller-supplied `identity_id` (`idt_` + UUID) and an ISO 8601 `dob` string:
+
+```typescript
+const { Identity } = blnk;
+
+const newIdentity = await Identity.create({
+  identity_id: 'idt_11111111-1111-4111-8111-111111111111',
+  identity_type: 'individual',
+  first_name: 'Jane',
+  last_name: 'Doe',
+  gender: 'female',
+  dob: '1990-01-15T00:00:00Z',
+  email_address: 'jane@example.com',
+  phone_number: '+1234567890',
+  nationality: 'US',
+  category: 'customer',
+  street: '123 Main St',
+  country: 'USA',
+  state: 'NY',
+  post_code: '10001',
+  city: 'New York',
+});
+console.log('Identity Created:', newIdentity);
+```
+
+---
+
+## 6. Creating Balances
 
 Balances represent the store of value within a ledger, like a wallet or account. Each balance belongs to a ledger.
 

--- a/src/blnk/endpoints/identity.ts
+++ b/src/blnk/endpoints/identity.ts
@@ -2,6 +2,7 @@ import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {IdentityData, IdentityDataResponse} from "../../types/identity";
 import {HandleError} from "../utils/logger";
+import {serializeIdentityData} from "../utils/identitySerialization";
 import {ValidateIdentity} from "../utils/validators/identityValidators";
 
 /**
@@ -59,10 +60,11 @@ export class Identity {
       if (validatorResponse) {
         return this.formatResponse(400, validatorResponse, null);
       }
+      const payload = serializeIdentityData(data);
       const response = await this.request<
         IdentityData<T>,
         IdentityDataResponse<T>
-      >(`identities`, data, `POST`);
+      >(`identities`, payload, `POST`);
       return response;
     } catch (error: unknown) {
       return HandleError(
@@ -165,10 +167,11 @@ export class Identity {
       if (validatorResponse) {
         return this.formatResponse(400, validatorResponse, null);
       }
+      const payload = serializeIdentityData(data);
       const response = await this.request<
         IdentityData<T>,
         IdentityDataResponse<T>
-      >(`identities/${id}`, data, `PUT`);
+      >(`identities/${id}`, payload, `PUT`);
       return response;
     } catch (error: unknown) {
       return HandleError(

--- a/src/blnk/utils/identitySerialization.ts
+++ b/src/blnk/utils/identitySerialization.ts
@@ -1,0 +1,21 @@
+import {IdentityData, IdentityDateInput} from "../../types/identity";
+import {
+  isValidTransactionDateInput,
+  serializeTransactionDate,
+} from "./transactionSerialization";
+
+export function isValidIdentityDateInput(value: IdentityDateInput): boolean {
+  return isValidTransactionDateInput(value);
+}
+
+/**
+ * Prepares an identity payload for the API, converting Date fields to ISO strings.
+ */
+export function serializeIdentityData<T extends Record<string, unknown>>(
+  data: IdentityData<T>,
+): IdentityData<T> {
+  return {
+    ...data,
+    dob: serializeTransactionDate(data.dob) as IdentityData<T>[`dob`],
+  };
+}

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -1,11 +1,21 @@
 import {IdentityData} from "../../../types/identity";
 import {isValidMetaData} from "./ledgerBalance";
+import {isValidIdentityDateInput} from "../identitySerialization";
+
+const IDENTITY_ID_PATTERN =
+  /^idt_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function ValidateIdentity<T extends Record<string, unknown>>(
   data: IdentityData<T>,
 ): string | null {
+  if (
+    data.identity_id !== undefined &&
+    !IDENTITY_ID_PATTERN.test(data.identity_id)
+  ) {
+    return `identity_id must start with idt_ followed by a valid UUID`;
+  }
+
   if (data.identity_type === `individual`) {
-    // Validate fields for individuals
     if (!data.first_name) {
       return `First name is required for individuals.`;
     }
@@ -15,6 +25,9 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
     if (!data.dob) {
       return `Date of birth is required for individuals.`;
     }
+    if (!isValidIdentityDateInput(data.dob)) {
+      return `dob must be a valid ISO 8601 date string or Date`;
+    }
     if (!data.gender) {
       return `Gender is required for individuals.`;
     }
@@ -22,13 +35,11 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
       return `Nationality is required for individuals.`;
     }
   } else if (data.identity_type === `organization`) {
-    // Validate fields for organizations
     if (!data.organization_name || data.organization_name.trim() === ``) {
       return `Organization name is required for organizations.`;
     }
   }
 
-  // Validate common fields for both individuals and organizations
   if (!data.street) {
     return `Street address is required.`;
   }
@@ -47,11 +58,9 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
   if (!data.category) {
     return `Category is required.`;
   }
-  // Validate meta_data if provided
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
   }
 
-  // Return errors if any, otherwise return an empty array
   return null;
 }

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -1,12 +1,17 @@
+export type IdentityDateInput = string | Date;
+
 type IdentityType = `individual` | `organization`;
 
 export interface IdentityData<T extends Record<string, unknown>> {
+  /** Optional caller-supplied id (`idt_` + UUID). */
+  identity_id?: string;
   identity_type: IdentityType;
   first_name?: string;
   last_name?: string;
   other_names?: string;
   gender?: `male` | `female` | `other`;
-  dob?: Date;
+  /** ISO 8601 string (RFC3339) or `Date` (serialized before the API call). */
+  dob?: IdentityDateInput;
   email_address: string;
   phone_number: string;
   nationality?: string;
@@ -22,7 +27,9 @@ export interface IdentityData<T extends Record<string, unknown>> {
 
 export interface IdentityDataResponse<
   T extends Record<string, unknown>,
-> extends IdentityData<T> {
+> extends Omit<IdentityData<T>, `dob`> {
   created_at: string;
   identity_id: string;
+  /** Date of birth as returned by the API (ISO 8601 string). */
+  dob?: string;
 }

--- a/tests/unit/blnk/endpoints/identity.test.ts
+++ b/tests/unit/blnk/endpoints/identity.test.ts
@@ -140,4 +140,123 @@ tap.test(`Identity`, async t => {
     childTest.equal(response.data, null);
     childTest.end();
   });
+
+  t.test(
+    `create forwards identity_id and ISO dob (issue #49)`,
+    async childTest => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const identity = new Identity(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: IdentityData<Record<string, unknown>> = {
+        identity_id: `idt_11111111-1111-4111-8111-111111111111`,
+        category: `customer`,
+        identity_type: `individual`,
+        first_name: `Jane`,
+        last_name: `Doe`,
+        gender: `female`,
+        dob: `1990-01-15T00:00:00Z`,
+        nationality: `US`,
+        city: `New York`,
+        country: `USA`,
+        email_address: `jane@example.com`,
+        state: `NY`,
+        post_code: `10001`,
+        street: `123 Main St`,
+        phone_number: `1234567890`,
+      };
+
+      await identity.create(data);
+
+      childTest.match(capturedRequest.args(), [
+        [
+          `identities`,
+          {
+            ...data,
+            dob: `1990-01-15T00:00:00Z`,
+          },
+          `POST`,
+        ],
+      ]);
+      childTest.end();
+    },
+  );
+
+  t.test(`create serializes Date dob (issue #49)`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const data: IdentityData<Record<string, unknown>> = {
+      category: `customer`,
+      identity_type: `individual`,
+      first_name: `Jane`,
+      last_name: `Doe`,
+      gender: `female`,
+      dob: new Date(`1990-01-15T00:00:00.000Z`),
+      nationality: `US`,
+      city: `New York`,
+      country: `USA`,
+      email_address: `jane@example.com`,
+      state: `NY`,
+      post_code: `10001`,
+      street: `123 Main St`,
+      phone_number: `1234567890`,
+    };
+
+    await identity.create(data);
+
+    childTest.match(capturedRequest.args(), [
+      [
+        `identities`,
+        {
+          ...data,
+          dob: `1990-01-15T00:00:00Z`,
+        },
+        `POST`,
+      ],
+    ]);
+    childTest.end();
+  });
+
+  t.test(`create rejects invalid identity_id (issue #49)`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const data: IdentityData<Record<string, unknown>> = {
+      identity_id: `user_123`,
+      category: `customer`,
+      identity_type: `individual`,
+      first_name: `Jane`,
+      last_name: `Doe`,
+      gender: `female`,
+      dob: `1990-01-15T00:00:00Z`,
+      nationality: `US`,
+      city: `New York`,
+      country: `USA`,
+      email_address: `jane@example.com`,
+      state: `NY`,
+      post_code: `10001`,
+      street: `123 Main St`,
+      phone_number: `1234567890`,
+    };
+
+    const response = await identity.create(data);
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `identity_id must start with idt_ followed by a valid UUID`,
+    );
+    childTest.end();
+  });
 });

--- a/tests/unit/blnk/utils/identitySerialization.test.ts
+++ b/tests/unit/blnk/utils/identitySerialization.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {serializeIdentityData} from "../../../../src/blnk/utils/identitySerialization";
+import {IdentityData} from "../../../../src/types/identity";
+
+const baseIndividual: IdentityData<Record<string, unknown>> = {
+  identity_type: `individual`,
+  first_name: `Jane`,
+  last_name: `Doe`,
+  gender: `female`,
+  nationality: `US`,
+  email_address: `jane@example.com`,
+  phone_number: `+1234567890`,
+  category: `customer`,
+  street: `123 Main St`,
+  country: `USA`,
+  state: `NY`,
+  post_code: `10001`,
+  city: `New York`,
+};
+
+tap.test(`Issue #49 — serializeIdentityData`, t => {
+  t.test(`passes through ISO dob string`, tt => {
+    const data = {
+      ...baseIndividual,
+      dob: `1990-01-15T00:00:00Z`,
+    };
+    const payload = serializeIdentityData(data);
+    tt.equal(payload.dob, `1990-01-15T00:00:00Z`);
+    tt.end();
+  });
+
+  t.test(`serializes Date dob to ISO string without milliseconds`, tt => {
+    const data = {
+      ...baseIndividual,
+      dob: new Date(`1990-01-15T00:00:00.000Z`),
+    };
+    const payload = serializeIdentityData(data);
+    tt.equal(payload.dob, `1990-01-15T00:00:00Z`);
+    tt.end();
+  });
+
+  t.test(`forwards optional identity_id`, tt => {
+    const data = {
+      ...baseIndividual,
+      identity_id: `idt_11111111-1111-4111-8111-111111111111`,
+      dob: `1990-01-15T00:00:00Z`,
+    };
+    const payload = serializeIdentityData(data);
+    tt.equal(payload.identity_id, `idt_11111111-1111-4111-8111-111111111111`);
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/unit/blnk/utils/identityValidators.test.ts
+++ b/tests/unit/blnk/utils/identityValidators.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateIdentity} from "../../../../src/blnk/utils/validators/identityValidators";
+
+const baseIndividual = {
+  identity_type: `individual` as const,
+  first_name: `Jane`,
+  last_name: `Doe`,
+  gender: `female` as const,
+  dob: `1990-01-15T00:00:00Z`,
+  nationality: `US`,
+  email_address: `jane@example.com`,
+  phone_number: `+1234567890`,
+  category: `customer`,
+  street: `123 Main St`,
+  country: `USA`,
+  state: `NY`,
+  post_code: `10001`,
+  city: `New York`,
+};
+
+tap.test(`Issue #49 — ValidateIdentity identity_id and dob`, t => {
+  t.test(`accepts caller-supplied identity_id`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        ...baseIndividual,
+        identity_id: `idt_11111111-1111-4111-8111-111111111111`,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`accepts ISO dob string`, tt => {
+    tt.equal(ValidateIdentity(baseIndividual), null);
+    tt.end();
+  });
+
+  t.test(`accepts Date dob`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        ...baseIndividual,
+        dob: new Date(`1990-01-15T00:00:00Z`),
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid identity_id`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        ...baseIndividual,
+        identity_id: `user_123`,
+      }),
+      `identity_id must start with idt_ followed by a valid UUID`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid dob string`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        ...baseIndividual,
+        dob: `not-a-date`,
+      }),
+      `dob must be a valid ISO 8601 date string or Date`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/unit/types/identityResponse.test.ts
+++ b/tests/unit/types/identityResponse.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {IdentityDataResponse} from "../../../src/types/identity";
+
+tap.test(`Issue #49 — IdentityDataResponse API parity`, t => {
+  t.test(`response dob is a string`, tt => {
+    const response: IdentityDataResponse<{customer_id: string}> = {
+      identity_id: `idt_11111111-1111-4111-8111-111111111111`,
+      identity_type: `individual`,
+      first_name: `Alice`,
+      last_name: `Smith`,
+      gender: `female`,
+      dob: `1985-05-15T00:00:00Z`,
+      email_address: `alice@example.com`,
+      phone_number: `+1234567890`,
+      nationality: `Canadian`,
+      category: `customer`,
+      street: `789 Elm St`,
+      country: `Canada`,
+      state: `Ontario`,
+      post_code: `M4B 1B3`,
+      city: `Toronto`,
+      created_at: `2024-11-26T08:36:36.238244338Z`,
+      meta_data: {customer_id: `CUST123456`},
+    };
+
+    tt.equal(typeof response.dob, `string`);
+    tt.equal(response.identity_id.startsWith(`idt_`), true);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add optional `identity_id` (`idt_` + UUID) to `IdentityData` with client-side validation
- Change `dob` to accept ISO 8601 strings or `Date`; serialize to RFC3339 before `POST /identities` and `PUT /identities/{id}`
- Update `IdentityDataResponse` so `dob` is typed as `string` per the [create-identity API reference](https://docs.blnkfinance.com/reference/create-identity)
- Unit tests for validators, serialization, endpoint forwarding, and response type parity
- README usage example

## Test plan
- [x] `npm run test:unit` — 509 pass
- [x] `npm run lint` — clean
- [ ] Postman **TS SDK (#49)** — `POST /identities` with caller-supplied `identity_id` and ISO `dob`

Closes #49