### PR TITLE
Relax Identity.create validation to match API optionality (closes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,19 @@ console.log('Ledger Updated:', updatedLedger);
 
 ## 5. Creating Identities
 
-Register customers or organizations before linking them to balances. Pass an optional caller-supplied `identity_id` (`idt_` + UUID) and an ISO 8601 `dob` string:
+Register customers or organizations before linking them to balances. Only `identity_type` is required; all other fields are optional and match the [Create Identity API reference](https://docs.blnkfinance.com/reference/create-identity). The SDK validates `identity_type` and field formats (for example `identity_id`, `dob`, `gender`) when you provide them.
+
+Minimal create:
+
+```typescript
+const { Identity } = blnk;
+
+const minimal = await Identity.create({
+  identity_type: 'individual',
+});
+```
+
+Full example with optional caller-supplied `identity_id` (`idt_` + UUID) and ISO 8601 `dob`:
 
 ```typescript
 const { Identity } = blnk;

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -5,9 +5,18 @@ import {isValidIdentityDateInput} from "../identitySerialization";
 const IDENTITY_ID_PATTERN =
   /^idt_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+const VALID_GENDERS = [`male`, `female`, `other`] as const;
+
 export function ValidateIdentity<T extends Record<string, unknown>>(
   data: IdentityData<T>,
 ): string | null {
+  if (
+    data.identity_type !== `individual` &&
+    data.identity_type !== `organization`
+  ) {
+    return `identity_type must be individual or organization`;
+  }
+
   if (
     data.identity_id !== undefined &&
     !IDENTITY_ID_PATTERN.test(data.identity_id)
@@ -15,49 +24,14 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
     return `identity_id must start with idt_ followed by a valid UUID`;
   }
 
-  if (data.identity_type === `individual`) {
-    if (!data.first_name) {
-      return `First name is required for individuals.`;
-    }
-    if (!data.last_name) {
-      return `Last name is required for individuals.`;
-    }
-    if (!data.dob) {
-      return `Date of birth is required for individuals.`;
-    }
-    if (!isValidIdentityDateInput(data.dob)) {
-      return `dob must be a valid ISO 8601 date string or Date`;
-    }
-    if (!data.gender) {
-      return `Gender is required for individuals.`;
-    }
-    if (!data.nationality) {
-      return `Nationality is required for individuals.`;
-    }
-  } else if (data.identity_type === `organization`) {
-    if (!data.organization_name || data.organization_name.trim() === ``) {
-      return `Organization name is required for organizations.`;
-    }
+  if (data.dob !== undefined && !isValidIdentityDateInput(data.dob)) {
+    return `dob must be a valid ISO 8601 date string or Date`;
   }
 
-  if (!data.street) {
-    return `Street address is required.`;
+  if (data.gender !== undefined && !VALID_GENDERS.includes(data.gender)) {
+    return `gender must be male, female, or other if provided`;
   }
-  if (!data.city) {
-    return `City is required.`;
-  }
-  if (!data.state) {
-    return `State is required.`;
-  }
-  if (!data.country) {
-    return `Country is required.`;
-  }
-  if (!data.post_code) {
-    return `Postal code is required.`;
-  }
-  if (!data.category) {
-    return `Category is required.`;
-  }
+
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
   }

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -12,16 +12,16 @@ export interface IdentityData<T extends Record<string, unknown>> {
   gender?: `male` | `female` | `other`;
   /** ISO 8601 string (RFC3339) or `Date` (serialized before the API call). */
   dob?: IdentityDateInput;
-  email_address: string;
-  phone_number: string;
+  email_address?: string;
+  phone_number?: string;
   nationality?: string;
   organization_name?: string;
-  category: string;
-  street: string;
-  country: string;
-  state: string;
-  post_code: string;
-  city: string;
+  category?: string;
+  street?: string;
+  country?: string;
+  state?: string;
+  post_code?: string;
+  city?: string;
   meta_data?: T;
 }
 

--- a/tests/unit/blnk/endpoints/identity.test.ts
+++ b/tests/unit/blnk/endpoints/identity.test.ts
@@ -41,7 +41,7 @@ tap.test(`Identity`, async t => {
   });
 
   t.test(
-    `It should handle missing fields if organization is selected`,
+    `create accepts minimal organization payload (issue #50)`,
     async childTest => {
       const mockLogger = createMockLogger();
       const thirdPartyRequest: BlnkRequest = createMockBlnkRequest(
@@ -56,27 +56,18 @@ tap.test(`Identity`, async t => {
         FormatResponse,
       );
       const data: IdentityData<{}> = {
-        category: `test`,
         identity_type: `organization`,
-        city: `test`,
-        country: `test`,
-        email_address: `test@test.com`,
-        state: `test`,
-        post_code: `test`,
-        street: `test`,
-        phone_number: `1234567890`,
       };
 
       const response = await identity.create(data);
-      childTest.match(capturedRequest.args(), []);
-      childTest.equal(response.data, null);
-      childTest.equal(response.status, 400);
+      childTest.match(capturedRequest.args(), [[`identities`, data, `POST`]]);
+      childTest.equal(response.status, 201);
       childTest.end();
     },
   );
 
   t.test(
-    `It should handle missing fields if individual is selected`,
+    `create accepts minimal individual payload (issue #50)`,
     async childTest => {
       const mockLogger = createMockLogger();
       const thirdPartyRequest: BlnkRequest = createMockBlnkRequest(
@@ -91,21 +82,12 @@ tap.test(`Identity`, async t => {
         FormatResponse,
       );
       const data: IdentityData<{}> = {
-        category: `test`,
         identity_type: `individual`,
-        city: `test`,
-        country: `test`,
-        email_address: `test@test.com`,
-        state: `test`,
-        post_code: `test`,
-        street: `test`,
-        phone_number: `1234567890`,
       };
 
       const response = await identity.create(data);
-      childTest.match(capturedRequest.args(), []);
-      childTest.equal(response.data, null);
-      childTest.equal(response.status, 400);
+      childTest.match(capturedRequest.args(), [[`identities`, data, `POST`]]);
+      childTest.equal(response.status, 201);
       childTest.end();
     },
   );

--- a/tests/unit/blnk/utils/identityValidators.test.ts
+++ b/tests/unit/blnk/utils/identityValidators.test.ts
@@ -71,3 +71,48 @@ tap.test(`Issue #49 — ValidateIdentity identity_id and dob`, t => {
 
   t.end();
 });
+
+tap.test(`Issue #50 — ValidateIdentity optional fields`, t => {
+  t.test(`accepts minimal individual payload`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        identity_type: `individual`,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`accepts minimal organization payload`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        identity_type: `organization`,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid identity_type`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        identity_type: `business` as `individual`,
+      }),
+      `identity_type must be individual or organization`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid gender when provided`, tt => {
+    tt.equal(
+      ValidateIdentity({
+        ...baseIndividual,
+        gender: `unknown` as `female`,
+      }),
+      `gender must be male, female, or other if provided`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Align `ValidateIdentity` with the Create Identity API reference: only `identity_type` is required; format checks apply when optional fields are provided (`identity_id`, `dob`, `gender`, `meta_data`).
- Make previously required `IdentityData` fields optional in TypeScript (`email_address`, address fields, `category`, etc.).
- Add unit tests for minimal individual/organization payloads and update README with a minimal create example.

## Test plan
- [x] `npm run test:unit` (identity + validator tests)
- [x] `npm run lint`
- [x] Postman **TS SDK (#50)** — `POST /identities` with `{ "identity_type": "individual" }` against Core 0.14.5