### PR TITLE
Add identities collection to Search.search (closes #51)

### DIFF
--- a/src/blnk/endpoints/search.ts
+++ b/src/blnk/endpoints/search.ts
@@ -1,7 +1,16 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
-import {SearchParams, SearchResponse} from "../../types/search";
+import {
+  SearchCollection,
+  SearchIdentityResponse,
+  SearchParams,
+  SearchResponse,
+} from "../../types/search";
 import {HandleError} from "../utils/logger";
+import {
+  ValidateSearchCollection,
+  ValidateSearchParams,
+} from "../utils/validators/searchValidators";
 
 /**
  * Represents a Search class that handles searching functionality.
@@ -12,13 +21,12 @@ import {HandleError} from "../utils/logger";
  * @param {FormatResponseType} formatResponse - The function for formatting API responses.
  * @method search - Performs a search operation based on the provided data and service type.
  * @param {SearchParams} data - The search parameters.
- * @param {`ledgers` | `transactions` | `balances`} service - The type of service to search within.
- * @returns {Promise<SearchResponse>} - A promise that resolves to the search response.
+ * @param {SearchCollection} service - The collection to search (`ledgers`, `transactions`, `balances`, or `identities`).
+ * @returns {Promise<SearchResponse | SearchIdentityResponse>} - A promise that resolves to the search response.
  * @example
  * const search = new Search(requestFunction, loggerInstance, formatResponseFunction);
- * const searchData = { q: 'search query', page: 1, per_page: 10 };
- * const searchService = 'ledgers';
- * const result = await search.search(searchData, searchService);
+ * const searchData = { q: 'jane', query_by: 'first_name,last_name,email_address', page: 1, per_page: 10 };
+ * const result = await search.search(searchData, 'identities');
  */
 export class Search {
   private request: BlnkRequest;
@@ -35,19 +43,22 @@ export class Search {
     this.formatResponse = formatResponse;
   }
 
-  async search(
-    data: SearchParams,
-    service: `ledgers` | `transactions` | `balances`,
-  ) {
+  async search(data: SearchParams, service: SearchCollection) {
     try {
-      if (!data.q) {
-        return this.formatResponse(400, `Field "q" must be filled`, null);
+      const collectionError = ValidateSearchCollection(service);
+      if (collectionError) {
+        return this.formatResponse(400, collectionError, null);
       }
-      const response = await this.request<SearchParams, SearchResponse>(
-        `search/${service}`,
-        data,
-        `POST`,
-      );
+
+      const paramsError = ValidateSearchParams(data);
+      if (paramsError) {
+        return this.formatResponse(400, paramsError, null);
+      }
+
+      const response = await this.request<
+        SearchParams,
+        SearchResponse | SearchIdentityResponse
+      >(`search/${service}`, data, `POST`);
 
       return response;
     } catch (error) {

--- a/src/blnk/utils/validators/searchValidators.ts
+++ b/src/blnk/utils/validators/searchValidators.ts
@@ -1,0 +1,57 @@
+import {SearchCollection, SearchParams} from "../../../types/search";
+
+const SEARCH_COLLECTIONS: SearchCollection[] = [
+  `ledgers`,
+  `transactions`,
+  `balances`,
+  `identities`,
+];
+
+const MAX_PER_PAGE = 250;
+
+export function ValidateSearchCollection(service: string): string | null {
+  if (!SEARCH_COLLECTIONS.includes(service as SearchCollection)) {
+    return `collection must be ledgers, transactions, balances, or identities`;
+  }
+  return null;
+}
+
+export function ValidateSearchParams(data: SearchParams): string | null {
+  if (!data || typeof data !== `object`) {
+    return `Search params must be a valid object`;
+  }
+
+  if (typeof data.q !== `string` || data.q.trim() === ``) {
+    return `Field "q" must be filled`;
+  }
+
+  if (
+    data.page !== undefined &&
+    (!Number.isInteger(data.page) || data.page < 1)
+  ) {
+    return `page must be a positive integer if provided`;
+  }
+
+  if (
+    data.per_page !== undefined &&
+    (!Number.isInteger(data.per_page) ||
+      data.per_page < 1 ||
+      data.per_page > MAX_PER_PAGE)
+  ) {
+    return `per_page must be an integer between 1 and 250 if provided`;
+  }
+
+  if (data.query_by !== undefined && typeof data.query_by !== `string`) {
+    return `query_by must be a string if provided`;
+  }
+
+  if (data.filter_by !== undefined && typeof data.filter_by !== `string`) {
+    return `filter_by must be a string if provided`;
+  }
+
+  if (data.sort_by !== undefined && typeof data.sort_by !== `string`) {
+    return `sort_by must be a string if provided`;
+  }
+
+  return null;
+}

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -7,11 +7,23 @@ export interface SearchParams {
   per_page?: number;
 }
 
+/** Collection names supported by `Search.search`. */
+export type SearchCollection =
+  | `ledgers`
+  | `transactions`
+  | `balances`
+  | `identities`;
+
+/** Request params echoed by Typesense (may include `collection_name`). */
+export interface SearchRequestParams extends SearchParams {
+  collection_name?: string;
+}
+
 export interface SearchResponse {
   found: number;
   out_of: number;
   page: number;
-  request_params: SearchParams;
+  request_params: SearchRequestParams;
   search_time_ms: number;
   hits: Array<{
     document: {
@@ -26,4 +38,48 @@ export interface SearchResponse {
       meta_data: unknown | null;
     };
   }>;
+}
+
+/** Identity document shape returned by `POST /search/identities`. */
+export interface SearchIdentityDocument {
+  id: string;
+  identity_id: string;
+  identity_type: string;
+  organization_name?: string;
+  category?: string;
+  first_name?: string;
+  last_name?: string;
+  other_names?: string;
+  gender?: string;
+  email_address?: string;
+  phone_number?: string;
+  nationality?: string;
+  street?: string;
+  country?: string;
+  state?: string;
+  post_code?: string;
+  city?: string;
+  /** Typesense-indexed date of birth (Unix timestamp seconds). */
+  dob?: number;
+  /** Typesense-indexed creation time (Unix timestamp seconds). */
+  created_at: number;
+  meta_data?: Record<string, unknown> | null;
+}
+
+export interface SearchIdentityHit {
+  document: SearchIdentityDocument;
+  highlights?: unknown[];
+  highlight?: Record<string, unknown>;
+  text_match?: number;
+}
+
+export interface SearchIdentityResponse {
+  found: number;
+  out_of: number;
+  page: number;
+  request_params: SearchRequestParams;
+  search_time_ms: number;
+  facet_counts?: unknown[];
+  search_cutoff?: boolean;
+  hits: SearchIdentityHit[];
 }

--- a/tests/unit/blnk/endpoints/search.test.ts
+++ b/tests/unit/blnk/endpoints/search.test.ts
@@ -1,0 +1,83 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Search} from "../../../../src/blnk/endpoints/search";
+import {
+  createMockBlnkRequest,
+  createMockLogger,
+} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {SearchParams} from "../../../../src/types/search";
+
+tap.test(`Issue #51 — Search.search identities collection`, async t => {
+  t.test(`search forwards identities collection`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const params: SearchParams = {
+      q: `jane`,
+      query_by: `first_name,last_name,email_address`,
+      per_page: 10,
+    };
+
+    const response = await search.search(params, `identities`);
+
+    childTest.match(capturedRequest.args(), [
+      [`search/identities`, params, `POST`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`search rejects invalid collection`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.search(
+      {q: `test`},
+      `accounts` as `identities`,
+    );
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `collection must be ledgers, transactions, balances, or identities`,
+    );
+    childTest.end();
+  });
+
+  t.test(`search rejects empty q`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.search({q: `   `}, `identities`);
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(response.message, `Field "q" must be filled`);
+    childTest.end();
+  });
+
+  t.test(`search rejects invalid per_page`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.search({q: `*`, per_page: 500}, `identities`);
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `per_page must be an integer between 1 and 250 if provided`,
+    );
+    childTest.end();
+  });
+});

--- a/tests/unit/blnk/utils/searchValidators.test.ts
+++ b/tests/unit/blnk/utils/searchValidators.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  ValidateSearchCollection,
+  ValidateSearchParams,
+} from "../../../../src/blnk/utils/validators/searchValidators";
+
+tap.test(`Issue #51 — search validators`, t => {
+  t.test(`ValidateSearchCollection accepts identities`, tt => {
+    tt.equal(ValidateSearchCollection(`identities`), null);
+    tt.equal(ValidateSearchCollection(`ledgers`), null);
+    tt.end();
+  });
+
+  t.test(`ValidateSearchCollection rejects unknown collection`, tt => {
+    tt.equal(
+      ValidateSearchCollection(`accounts`),
+      `collection must be ledgers, transactions, balances, or identities`,
+    );
+    tt.end();
+  });
+
+  t.test(`ValidateSearchParams accepts API-valid payload`, tt => {
+    tt.equal(
+      ValidateSearchParams({
+        q: `*`,
+        query_by: `first_name,last_name,email_address`,
+        filter_by: `identity_type:=individual`,
+        sort_by: `created_at:desc`,
+        page: 1,
+        per_page: 25,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`ValidateSearchParams rejects empty q`, tt => {
+    tt.equal(ValidateSearchParams({q: ``}), `Field "q" must be filled`);
+    tt.end();
+  });
+
+  t.test(`ValidateSearchParams rejects invalid page`, tt => {
+    tt.equal(
+      ValidateSearchParams({q: `*`, page: 0}),
+      `page must be a positive integer if provided`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/unit/types/searchIdentityResponse.test.ts
+++ b/tests/unit/types/searchIdentityResponse.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  SearchIdentityDocument,
+  SearchIdentityResponse,
+} from "../../../src/types/search";
+
+tap.test(`Issue #51 — SearchIdentityResponse API parity`, t => {
+  t.test(`identity document includes indexed fields`, tt => {
+    const response: SearchIdentityResponse = {
+      found: 1,
+      out_of: 13,
+      page: 1,
+      request_params: {
+        collection_name: `identities`,
+        q: `*`,
+        per_page: 1,
+      },
+      search_time_ms: 5,
+      hits: [
+        {
+          document: {
+            id: `idt_fbf6a26c-82c6-46fb-9237-8fbba55a23c0`,
+            identity_id: `idt_fbf6a26c-82c6-46fb-9237-8fbba55a23c0`,
+            identity_type: `organization`,
+            created_at: 1781225782,
+            dob: -62135596800,
+            meta_data: {},
+          } as SearchIdentityDocument,
+          highlights: [],
+        },
+      ],
+    };
+
+    tt.equal(typeof response.hits[0].document.created_at, `number`);
+    tt.equal(response.hits[0].document.identity_id.startsWith(`idt_`), true);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `identities` to the `Search.search` collection union (`SearchCollection` type).
- Introduce `SearchIdentityDocument`, `SearchIdentityHit`, and `SearchIdentityResponse` matching Typesense-indexed identity fields (`created_at`/`dob` as Unix timestamps).
- Add `ValidateSearchCollection` and `ValidateSearchParams` for API-valid payloads (collection name, `q`, pagination bounds).
- Unit tests for endpoint routing, validators, and identity response typing.

## Test plan
- [x] `npm run test:unit` (536 passing)
- [x] `npm run lint`
- [x] Postman **TS SDK (#51)** — `POST /search/identities` with `query_by` against Core 0.14.5