### PR TITLE
Add generic SearchResponse types per collection (closes #52)

### DIFF
--- a/src/blnk/endpoints/search.ts
+++ b/src/blnk/endpoints/search.ts
@@ -5,14 +5,10 @@ import {
   FormatResponseType,
 } from "../../types/general";
 import {
-  SearchBalanceDocument,
   SearchCollection,
   SearchDocumentByCollection,
-  SearchIdentityDocument,
-  SearchLedgerDocument,
   SearchParams,
   SearchResponse,
-  SearchTransactionDocument,
 } from "../../types/search";
 import {HandleError} from "../utils/logger";
 import {
@@ -39,23 +35,12 @@ export class Search {
     this.formatResponse = formatResponse;
   }
 
-  async search(
+  async search<C extends SearchCollection>(
     data: SearchParams,
-    service: `ledgers`,
-  ): Promise<ApiResponse<SearchResponse<SearchLedgerDocument> | null>>;
-  async search(
-    data: SearchParams,
-    service: `transactions`,
-  ): Promise<ApiResponse<SearchResponse<SearchTransactionDocument> | null>>;
-  async search(
-    data: SearchParams,
-    service: `balances`,
-  ): Promise<ApiResponse<SearchResponse<SearchBalanceDocument> | null>>;
-  async search(
-    data: SearchParams,
-    service: `identities`,
-  ): Promise<ApiResponse<SearchResponse<SearchIdentityDocument> | null>>;
-  async search(data: SearchParams, service: SearchCollection) {
+    service: C,
+  ): Promise<
+    ApiResponse<SearchResponse<SearchDocumentByCollection[C]> | null>
+  > {
     try {
       const collectionError = ValidateSearchCollection(service);
       if (collectionError) {

--- a/src/blnk/endpoints/search.ts
+++ b/src/blnk/endpoints/search.ts
@@ -1,10 +1,18 @@
 import {BlnkLogger} from "../../types/blnkClient";
-import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
+  ApiResponse,
+  BlnkRequest,
+  FormatResponseType,
+} from "../../types/general";
+import {
+  SearchBalanceDocument,
   SearchCollection,
-  SearchIdentityResponse,
+  SearchDocumentByCollection,
+  SearchIdentityDocument,
+  SearchLedgerDocument,
   SearchParams,
   SearchResponse,
+  SearchTransactionDocument,
 } from "../../types/search";
 import {HandleError} from "../utils/logger";
 import {
@@ -15,18 +23,6 @@ import {
 /**
  * Represents a Search class that handles searching functionality.
  * see @link https://docs.blnkfinance.com/search/overview for more details.
- * @constructor
- * @param {BlnkRequest} request - The request function for API calls.
- * @param {BlnkLogger} logger - The logger for handling logs.
- * @param {FormatResponseType} formatResponse - The function for formatting API responses.
- * @method search - Performs a search operation based on the provided data and service type.
- * @param {SearchParams} data - The search parameters.
- * @param {SearchCollection} service - The collection to search (`ledgers`, `transactions`, `balances`, or `identities`).
- * @returns {Promise<SearchResponse | SearchIdentityResponse>} - A promise that resolves to the search response.
- * @example
- * const search = new Search(requestFunction, loggerInstance, formatResponseFunction);
- * const searchData = { q: 'jane', query_by: 'first_name,last_name,email_address', page: 1, per_page: 10 };
- * const result = await search.search(searchData, 'identities');
  */
 export class Search {
   private request: BlnkRequest;
@@ -43,6 +39,22 @@ export class Search {
     this.formatResponse = formatResponse;
   }
 
+  async search(
+    data: SearchParams,
+    service: `ledgers`,
+  ): Promise<ApiResponse<SearchResponse<SearchLedgerDocument> | null>>;
+  async search(
+    data: SearchParams,
+    service: `transactions`,
+  ): Promise<ApiResponse<SearchResponse<SearchTransactionDocument> | null>>;
+  async search(
+    data: SearchParams,
+    service: `balances`,
+  ): Promise<ApiResponse<SearchResponse<SearchBalanceDocument> | null>>;
+  async search(
+    data: SearchParams,
+    service: `identities`,
+  ): Promise<ApiResponse<SearchResponse<SearchIdentityDocument> | null>>;
   async search(data: SearchParams, service: SearchCollection) {
     try {
       const collectionError = ValidateSearchCollection(service);
@@ -57,7 +69,7 @@ export class Search {
 
       const response = await this.request<
         SearchParams,
-        SearchResponse | SearchIdentityResponse
+        SearchResponse<SearchDocumentByCollection[typeof service]>
       >(`search/${service}`, data, `POST`);
 
       return response;

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -19,19 +19,23 @@ export interface SearchRequestParams extends SearchParams {
   collection_name?: string;
 }
 
-export interface SearchHit<TDocument> {
+export interface SearchHit<TDocument = SearchBalanceDocument> {
   document: TDocument;
   highlights?: unknown[];
   highlight?: Record<string, unknown>;
   text_match?: number;
 }
 
-export interface SearchGroupedHit<TDocument> {
+export interface SearchGroupedHit<TDocument = SearchBalanceDocument> {
   group_key?: string[];
   hits: SearchHit<TDocument>[];
 }
 
-export interface SearchResponse<TDocument> {
+/**
+ * Generic Typesense search response. Defaults to `SearchBalanceDocument` so
+ * existing `SearchResponse` imports remain valid without a type argument.
+ */
+export interface SearchResponse<TDocument = SearchBalanceDocument> {
   found: number;
   out_of: number;
   page: number;

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -19,25 +19,93 @@ export interface SearchRequestParams extends SearchParams {
   collection_name?: string;
 }
 
-export interface SearchResponse {
+export interface SearchHit<TDocument> {
+  document: TDocument;
+  highlights?: unknown[];
+  highlight?: Record<string, unknown>;
+  text_match?: number;
+}
+
+export interface SearchGroupedHit<TDocument> {
+  group_key?: string[];
+  hits: SearchHit<TDocument>[];
+}
+
+export interface SearchResponse<TDocument> {
   found: number;
   out_of: number;
   page: number;
   request_params: SearchRequestParams;
   search_time_ms: number;
-  hits: Array<{
-    document: {
-      balance_id: string;
-      balance: number;
-      credit_balance: number;
-      debit_balance: number;
-      currency: string;
-      precision: number;
-      ledger_id: string;
-      created_at: string;
-      meta_data: unknown | null;
-    };
-  }>;
+  facet_counts?: unknown[];
+  search_cutoff?: boolean;
+  hits: SearchHit<TDocument>[];
+  grouped_hits?: SearchGroupedHit<TDocument>[];
+}
+
+/** Ledger document shape returned by `POST /search/ledgers`. */
+export interface SearchLedgerDocument {
+  id: string;
+  ledger_id: string;
+  name: string;
+  /** Typesense-indexed creation time (Unix timestamp seconds). */
+  created_at: number;
+  meta_data?: Record<string, unknown> | null;
+}
+
+/** Balance document shape returned by `POST /search/balances`. */
+export interface SearchBalanceDocument {
+  id: string;
+  balance_id: string;
+  balance: string;
+  credit_balance?: string;
+  debit_balance?: string;
+  inflight_balance?: string;
+  inflight_credit_balance?: string;
+  inflight_debit_balance?: string;
+  currency?: string;
+  precision?: number;
+  ledger_id?: string;
+  identity_id?: string;
+  indicator?: string;
+  version?: number;
+  allocation_strategy?: string;
+  track_fund_lineage?: boolean;
+  currency_multiplier?: number;
+  inflight_expires_at?: number;
+  /** Typesense-indexed creation time (Unix timestamp seconds). */
+  created_at: number;
+  meta_data?: Record<string, unknown> | null;
+}
+
+/** Transaction document shape returned by `POST /search/transactions`. */
+export interface SearchTransactionDocument {
+  id: string;
+  transaction_id: string;
+  amount?: number;
+  amount_string?: string;
+  precise_amount?: string;
+  precision?: number;
+  source?: string;
+  destination?: string;
+  reference?: string;
+  description?: string;
+  currency?: string;
+  status?: string;
+  hash?: string;
+  parent_transaction?: string;
+  atomic?: boolean;
+  inflight?: boolean;
+  allow_overdraft?: boolean;
+  overdraft_limit?: number;
+  skip_queue?: boolean;
+  rate?: number;
+  /** Typesense-indexed creation time (Unix timestamp seconds). */
+  created_at: number;
+  scheduled_for?: number;
+  inflight_expiry_date?: number;
+  effective_date?: number;
+  meta_data?: Record<string, unknown> | null;
 }
 
 /** Identity document shape returned by `POST /search/identities`. */
@@ -66,20 +134,20 @@ export interface SearchIdentityDocument {
   meta_data?: Record<string, unknown> | null;
 }
 
-export interface SearchIdentityHit {
-  document: SearchIdentityDocument;
-  highlights?: unknown[];
-  highlight?: Record<string, unknown>;
-  text_match?: number;
-}
+export type SearchDocumentByCollection = {
+  ledgers: SearchLedgerDocument;
+  transactions: SearchTransactionDocument;
+  balances: SearchBalanceDocument;
+  identities: SearchIdentityDocument;
+};
 
-export interface SearchIdentityResponse {
-  found: number;
-  out_of: number;
-  page: number;
-  request_params: SearchRequestParams;
-  search_time_ms: number;
-  facet_counts?: unknown[];
-  search_cutoff?: boolean;
-  hits: SearchIdentityHit[];
-}
+export type SearchResponseByCollection = {
+  [K in SearchCollection]: SearchResponse<SearchDocumentByCollection[K]>;
+};
+
+export type SearchIdentityHit = SearchHit<SearchIdentityDocument>;
+export type SearchIdentityResponse = SearchResponse<SearchIdentityDocument>;
+export type SearchLedgerResponse = SearchResponse<SearchLedgerDocument>;
+export type SearchBalanceResponse = SearchResponse<SearchBalanceDocument>;
+export type SearchTransactionResponse =
+  SearchResponse<SearchTransactionDocument>;

--- a/tests/helpers/searchSearchInference.ts
+++ b/tests/helpers/searchSearchInference.ts
@@ -1,5 +1,9 @@
 import {Search} from "../../src/blnk/endpoints/search";
-import {SearchCollection, SearchParams} from "../../src/types/search";
+import {
+  SearchCollection,
+  SearchParams,
+  SearchResponse,
+} from "../../src/types/search";
 
 /** Compile-time checks for `Search.search` overload inference (issue #52). */
 export async function assertSearchSearchTypes(search: Search): Promise<void> {
@@ -26,4 +30,32 @@ export async function assertSearchSearchTypes(search: Search): Promise<void> {
     }
   };
   void dynamicSearch;
+}
+
+/** Ensures unparameterized `SearchResponse` imports still compile (SDK compat). */
+export function assertLegacySearchResponseUsage(): void {
+  const response: SearchResponse = {
+    found: 1,
+    out_of: 45,
+    page: 1,
+    request_params: {collection_name: `balances`, q: `*`},
+    search_time_ms: 1,
+    hits: [
+      {
+        document: {
+          id: `bln_15168eb4-bdb1-4e46-9331-f58a6a16b254`,
+          balance_id: `bln_15168eb4-bdb1-4e46-9331-f58a6a16b254`,
+          balance: `0`,
+          credit_balance: `0`,
+          debit_balance: `0`,
+          currency: `USD`,
+          ledger_id: `ldg_0921bd99-ff7c-4a06-b6d7-319f0bb12f87`,
+          created_at: 1781222909,
+        },
+      },
+    ],
+  };
+
+  const balanceId: string = response.hits[0].document.balance_id;
+  void balanceId;
 }

--- a/tests/helpers/searchSearchInference.ts
+++ b/tests/helpers/searchSearchInference.ts
@@ -1,0 +1,29 @@
+import {Search} from "../../src/blnk/endpoints/search";
+import {SearchCollection, SearchParams} from "../../src/types/search";
+
+/** Compile-time checks for `Search.search` overload inference (issue #52). */
+export async function assertSearchSearchTypes(search: Search): Promise<void> {
+  const params: SearchParams = {q: `*`};
+
+  const transactionsResponse = await search.search(params, `transactions`);
+  const transactionHit = transactionsResponse.data?.hits[0];
+  if (transactionHit) {
+    const status: string | undefined = transactionHit.document.status;
+    const transactionId: string = transactionHit.document.transaction_id;
+    void status;
+    void transactionId;
+    // @ts-expect-error balance is indexed on balance documents only
+    const _balance: string = transactionHit.document.balance;
+    void _balance;
+  }
+
+  const dynamicSearch = async (service: SearchCollection) => {
+    const response = await search.search(params, service);
+    const hit = response.data?.hits[0];
+    if (hit) {
+      const id: string = hit.document.id;
+      void id;
+    }
+  };
+  void dynamicSearch;
+}

--- a/tests/unit/blnk/endpoints/search.test.ts
+++ b/tests/unit/blnk/endpoints/search.test.ts
@@ -64,6 +64,41 @@ tap.test(`Issue #51 — Search.search identities collection`, async t => {
     childTest.end();
   });
 
+  t.test(`search forwards ledgers collection (issue #52)`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const params: SearchParams = {q: `General`, per_page: 5};
+    const response = await search.search(params, `ledgers`);
+
+    childTest.match(capturedRequest.args(), [
+      [`search/ledgers`, params, `POST`],
+    ]);
+    childTest.equal(response.status, 201);
+    childTest.end();
+  });
+
+  t.test(
+    `search forwards transactions collection (issue #52)`,
+    async childTest => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+      const params: SearchParams = {q: `payment`, per_page: 5};
+      const response = await search.search(params, `transactions`);
+
+      childTest.match(capturedRequest.args(), [
+        [`search/transactions`, params, `POST`],
+      ]);
+      childTest.equal(response.status, 201);
+      childTest.end();
+    },
+  );
+
   t.test(`search rejects invalid per_page`, async childTest => {
     const mockLogger = createMockLogger();
     const thirdPartyRequest = createMockBlnkRequest(true);

--- a/tests/unit/types/searchResponse.test.ts
+++ b/tests/unit/types/searchResponse.test.ts
@@ -1,12 +1,21 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
+import {Search} from "../../../src/blnk/endpoints/search";
+import {FormatResponse} from "../../../src/blnk/utils/httpClient";
+import {BlnkRequest} from "../../../src/types/general";
+import {
+  createMockBlnkRequest,
+  createMockLogger,
+} from "../../mocks/blnkClientMocks";
 import {
   SearchBalanceDocument,
+  SearchCollection,
   SearchIdentityDocument,
   SearchLedgerDocument,
   SearchResponse,
   SearchTransactionDocument,
 } from "../../../src/types/search";
+import {assertSearchSearchTypes} from "../../helpers/searchSearchInference";
 
 tap.test(`Issue #52 — SearchResponse per collection`, t => {
   t.test(`ledger document uses indexed fields`, tt => {
@@ -108,6 +117,66 @@ tap.test(`Issue #52 — SearchResponse per collection`, t => {
     };
 
     tt.equal(response.hits[0].document.identity_id.startsWith(`idt_`), true);
+    tt.end();
+  });
+
+  t.test(`Search.search infers transaction document fields`, async tt => {
+    const transactionSearchResponse: SearchResponse<SearchTransactionDocument> =
+      {
+        found: 1,
+        out_of: 11,
+        page: 1,
+        request_params: {collection_name: `transactions`, q: `payment`},
+        search_time_ms: 2,
+        hits: [
+          {
+            document: {
+              id: `txn_8bb67c99-70b1-46c2-aa49-1ea3fc2f2233`,
+              transaction_id: `txn_8bb67c99-70b1-46c2-aa49-1ea3fc2f2233`,
+              status: `APPLIED`,
+              precise_amount: `250000`,
+              created_at: 1781028226,
+            },
+          },
+        ],
+      };
+
+    const mockRequest: BlnkRequest = async () => ({
+      status: 201,
+      message: `Success`,
+      data: transactionSearchResponse,
+    });
+
+    const search = new Search(mockRequest, createMockLogger(), FormatResponse);
+    const response = await search.search({q: `payment`}, `transactions`);
+
+    tt.equal(response.status, 201);
+    tt.equal(response.data?.hits[0]?.document.status, `APPLIED`);
+    tt.equal(
+      response.data?.hits[0]?.document.transaction_id,
+      `txn_8bb67c99-70b1-46c2-aa49-1ea3fc2f2233`,
+    );
+    tt.end();
+  });
+
+  t.test(
+    `Search.search accepts dynamic SearchCollection variable`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = createMockBlnkRequest(true, undefined, 201);
+      const search = new Search(thirdPartyRequest, mockLogger, FormatResponse);
+      const service: SearchCollection = `ledgers`;
+
+      const response = await search.search({q: `General`}, service);
+
+      tt.equal(response.status, 201);
+      tt.end();
+    },
+  );
+
+  t.test(`compile-time Search.search inference checks`, tt => {
+    void assertSearchSearchTypes;
+    tt.pass(`searchSearchInference.ts type checks compile`);
     tt.end();
   });
 

--- a/tests/unit/types/searchResponse.test.ts
+++ b/tests/unit/types/searchResponse.test.ts
@@ -15,7 +15,10 @@ import {
   SearchResponse,
   SearchTransactionDocument,
 } from "../../../src/types/search";
-import {assertSearchSearchTypes} from "../../helpers/searchSearchInference";
+import {
+  assertLegacySearchResponseUsage,
+  assertSearchSearchTypes,
+} from "../../helpers/searchSearchInference";
 
 tap.test(`Issue #52 — SearchResponse per collection`, t => {
   t.test(`ledger document uses indexed fields`, tt => {
@@ -141,10 +144,14 @@ tap.test(`Issue #52 — SearchResponse per collection`, t => {
         ],
       };
 
-    const mockRequest: BlnkRequest = async () => ({
+    const mockRequest: BlnkRequest = async <T, R>(
+      _endpoint: string,
+      _data: T,
+      _method: `POST` | `GET` | `PUT` | `DELETE`,
+    ) => ({
       status: 201,
       message: `Success`,
-      data: transactionSearchResponse,
+      data: transactionSearchResponse as unknown as R,
     });
 
     const search = new Search(mockRequest, createMockLogger(), FormatResponse);
@@ -174,8 +181,33 @@ tap.test(`Issue #52 — SearchResponse per collection`, t => {
     },
   );
 
+  t.test(`unparameterized SearchResponse remains valid`, tt => {
+    const response: SearchResponse = {
+      found: 1,
+      out_of: 45,
+      page: 1,
+      request_params: {collection_name: `balances`, q: `*`},
+      search_time_ms: 1,
+      hits: [
+        {
+          document: {
+            id: `bln_15168eb4-bdb1-4e46-9331-f58a6a16b254`,
+            balance_id: `bln_15168eb4-bdb1-4e46-9331-f58a6a16b254`,
+            balance: `0`,
+            created_at: 1781222909,
+          },
+        },
+      ],
+    };
+
+    tt.equal(typeof response.hits[0].document.balance, `string`);
+    tt.equal(response.hits[0].document.balance_id.startsWith(`bln_`), true);
+    tt.end();
+  });
+
   t.test(`compile-time Search.search inference checks`, tt => {
     void assertSearchSearchTypes;
+    void assertLegacySearchResponseUsage;
     tt.pass(`searchSearchInference.ts type checks compile`);
     tt.end();
   });

--- a/tests/unit/types/searchResponse.test.ts
+++ b/tests/unit/types/searchResponse.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  SearchBalanceDocument,
+  SearchIdentityDocument,
+  SearchLedgerDocument,
+  SearchResponse,
+  SearchTransactionDocument,
+} from "../../../src/types/search";
+
+tap.test(`Issue #52 — SearchResponse per collection`, t => {
+  t.test(`ledger document uses indexed fields`, tt => {
+    const response: SearchResponse<SearchLedgerDocument> = {
+      found: 1,
+      out_of: 15,
+      page: 1,
+      request_params: {collection_name: `ledgers`, q: `*`},
+      search_time_ms: 0,
+      hits: [
+        {
+          document: {
+            id: `general_ledger_id`,
+            ledger_id: `general_ledger_id`,
+            name: `General Ledger`,
+            created_at: 1781226501,
+          },
+        },
+      ],
+    };
+
+    tt.equal(typeof response.hits[0].document.created_at, `number`);
+    tt.equal(response.hits[0].document.ledger_id, `general_ledger_id`);
+    tt.end();
+  });
+
+  t.test(`balance document uses string minor-unit fields`, tt => {
+    const response: SearchResponse<SearchBalanceDocument> = {
+      found: 1,
+      out_of: 45,
+      page: 1,
+      request_params: {collection_name: `balances`, q: `*`},
+      search_time_ms: 1,
+      hits: [
+        {
+          document: {
+            id: `bln_15168eb4-bdb1-4e46-9331-f58a6a16b254`,
+            balance_id: `bln_15168eb4-bdb1-4e46-9331-f58a6a16b254`,
+            balance: `0`,
+            credit_balance: `0`,
+            debit_balance: `0`,
+            currency: `USD`,
+            ledger_id: `ldg_0921bd99-ff7c-4a06-b6d7-319f0bb12f87`,
+            created_at: 1781222909,
+            track_fund_lineage: true,
+          },
+        },
+      ],
+    };
+
+    tt.equal(typeof response.hits[0].document.balance, `string`);
+    tt.equal(response.hits[0].document.balance_id.startsWith(`bln_`), true);
+    tt.end();
+  });
+
+  t.test(`transaction document includes status and precise_amount`, tt => {
+    const response: SearchResponse<SearchTransactionDocument> = {
+      found: 1,
+      out_of: 11,
+      page: 1,
+      request_params: {collection_name: `transactions`, q: `*`},
+      search_time_ms: 2,
+      hits: [
+        {
+          document: {
+            id: `txn_8bb67c99-70b1-46c2-aa49-1ea3fc2f2233`,
+            transaction_id: `txn_8bb67c99-70b1-46c2-aa49-1ea3fc2f2233`,
+            amount: 250000,
+            precise_amount: `250000`,
+            status: `APPLIED`,
+            created_at: 1781028226,
+          },
+        },
+      ],
+    };
+
+    tt.equal(response.hits[0].document.status, `APPLIED`);
+    tt.equal(typeof response.hits[0].document.created_at, `number`);
+    tt.end();
+  });
+
+  t.test(`identity document includes indexed fields`, tt => {
+    const response: SearchResponse<SearchIdentityDocument> = {
+      found: 1,
+      out_of: 13,
+      page: 1,
+      request_params: {collection_name: `identities`, q: `*`},
+      search_time_ms: 5,
+      hits: [
+        {
+          document: {
+            id: `idt_fbf6a26c-82c6-46fb-9237-8fbba55a23c0`,
+            identity_id: `idt_fbf6a26c-82c6-46fb-9237-8fbba55a23c0`,
+            identity_type: `organization`,
+            created_at: 1781225782,
+          },
+        },
+      ],
+    };
+
+    tt.equal(response.hits[0].document.identity_id.startsWith(`idt_`), true);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Replace balance-only `SearchResponse` hit documents with generic `SearchResponse<TDocument>` and per-collection document types (`SearchLedgerDocument`, `SearchBalanceDocument`, `SearchTransactionDocument`, `SearchIdentityDocument`).
- Add `SearchDocumentByCollection` / `SearchResponseByCollection` maps and generic `Search.search<C extends SearchCollection>()` so literal and dynamic collection arguments both compile with correct inference.
- Add type tests for all four collection document shapes, `Search.search()` inference, dynamic `SearchCollection` forwarding, and unparameterized `SearchResponse` usage.

## Breaking change (intentional — issue #52)
Unparameterized `SearchResponse` still compiles (defaults to `SearchBalanceDocument`), but **field types are corrected** to match the Typesense / Core 0.14.5 reference:

| Field | Before (`main`) | After (this PR) |
|-------|-----------------|-----------------|
| `balance`, `credit_balance`, `debit_balance` | `number` | `string` (minor units) |
| `created_at` | `string` | `number` (Unix timestamp seconds) |

This is intentional per issue #52 acceptance criteria ("response types match reference"). The old unparameterized shape is treated as a pre-#52 typing bug, not preserved via a legacy alias.

Consumers should use collection-specific types (`SearchTransactionDocument`, `Search.search(..., 'transactions')`, etc.) for full per-collection typing.

## Review follow-ups addressed
- **Dynamic `SearchCollection`:** generic `search<C>()` replaces literal-only overloads.
- **Default generic:** `SearchResponse`, `SearchHit`, and `SearchGroupedHit` default to `SearchBalanceDocument`.
- **Merge path:** Option A (correct types per reference) agreed with reviewer — no `LegacySearchResponse` alias.

## Test plan
- [x] `npm run test:unit` (557 passing)
- [x] `npm run lint`
- [x] Postman **TS SDK (#52)** — green against Core 0.14.5

Closes #52