### PR TITLE
Add Search.filter (POST /{collection}/filter) (closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,53 @@ The Blnk CLI allows you to list all ledgers, balances, and transactions quickly:
 
 ---
 
+## Search
+
+Blnk supports two search modes on the `Search` service:
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `Search.search(params, collection)` | `POST /search/{collection}` | Full-text search via Typesense |
+| `Search.filter(params, collection)` | `POST /{collection}/filter` | Structured DB filters (Core 0.13.2+) |
+
+Collections: `ledgers`, `balances`, `transactions`, `identities`.
+
+### Typesense search
+
+```typescript
+const { Search } = blnk;
+
+const results = await Search.search(
+  { q: 'payment', per_page: 10 },
+  'transactions',
+);
+```
+
+### DB filter
+
+```typescript
+const { Search } = blnk;
+
+const filtered = await Search.filter(
+  {
+    filters: [{ field: 'status', operator: 'eq', value: 'APPLIED' }],
+    logical_operator: 'and',
+    sort_by: 'created_at',
+    sort_order: 'desc',
+    include_count: true,
+    limit: 20,
+    offset: 0,
+  },
+  'transactions',
+);
+// filtered.data?.data — matching transaction records
+// filtered.data?.total_count — present when include_count is true
+```
+
+See the [Search via DB reference](https://docs.blnkfinance.com/reference/search-db) for supported operators and fields.
+
+---
+
 ## Additional Resources
 
 For more examples and advanced use cases, please refer to the [Examples Code](https://github.com/blnkfinance/blnk-ts/tree/main/examples).

--- a/src/blnk/endpoints/search.ts
+++ b/src/blnk/endpoints/search.ts
@@ -5,6 +5,9 @@ import {
   FormatResponseType,
 } from "../../types/general";
 import {
+  FilterParams,
+  FilterRecordByCollection,
+  FilterResponse,
   SearchCollection,
   SearchDocumentByCollection,
   SearchParams,
@@ -12,6 +15,7 @@ import {
 } from "../../types/search";
 import {HandleError} from "../utils/logger";
 import {
+  ValidateFilterParams,
   ValidateSearchCollection,
   ValidateSearchParams,
 } from "../utils/validators/searchValidators";
@@ -64,6 +68,37 @@ export class Search {
         this.logger,
         this.formatResponse,
         this.search.name,
+      );
+    }
+  }
+
+  async filter<C extends SearchCollection>(
+    data: FilterParams,
+    collection: C,
+  ): Promise<ApiResponse<FilterResponse<FilterRecordByCollection[C]> | null>> {
+    try {
+      const collectionError = ValidateSearchCollection(collection);
+      if (collectionError) {
+        return this.formatResponse(400, collectionError, null);
+      }
+
+      const paramsError = ValidateFilterParams(data);
+      if (paramsError) {
+        return this.formatResponse(400, paramsError, null);
+      }
+
+      const response = await this.request<
+        FilterParams,
+        FilterResponse<FilterRecordByCollection[typeof collection]>
+      >(`${collection}/filter`, data, `POST`);
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.filter.name,
       );
     }
   }

--- a/src/blnk/utils/validators/searchValidators.ts
+++ b/src/blnk/utils/validators/searchValidators.ts
@@ -1,4 +1,12 @@
-import {SearchCollection, SearchParams} from "../../../types/search";
+import {
+  FilterCondition,
+  FilterLogicalOperator,
+  FilterOperator,
+  FilterParams,
+  FilterSortOrder,
+  SearchCollection,
+  SearchParams,
+} from "../../../types/search";
 
 const SEARCH_COLLECTIONS: SearchCollection[] = [
   `ledgers`,
@@ -51,6 +59,134 @@ export function ValidateSearchParams(data: SearchParams): string | null {
 
   if (data.sort_by !== undefined && typeof data.sort_by !== `string`) {
     return `sort_by must be a string if provided`;
+  }
+
+  return null;
+}
+
+const FILTER_OPERATORS: FilterOperator[] = [
+  `eq`,
+  `ne`,
+  `gt`,
+  `gte`,
+  `lt`,
+  `lte`,
+  `in`,
+  `between`,
+  `like`,
+  `ilike`,
+  `isnull`,
+  `isnotnull`,
+];
+
+const VALUELESS_OPERATORS: FilterOperator[] = [`isnull`, `isnotnull`];
+const VALUES_ARRAY_OPERATORS: FilterOperator[] = [`in`, `between`];
+
+const MAX_FILTER_LIMIT = 100;
+
+function isFilterLogicalOperator(
+  value: string,
+): value is FilterLogicalOperator {
+  return value === `and` || value === `or`;
+}
+
+function isFilterSortOrder(value: string): value is FilterSortOrder {
+  return value === `asc` || value === `desc`;
+}
+
+function validateFilterCondition(
+  filter: FilterCondition,
+  index: number,
+): string | null {
+  if (!filter || typeof filter !== `object`) {
+    return `filters[${index}] must be a valid object`;
+  }
+
+  if (typeof filter.field !== `string` || filter.field.trim() === ``) {
+    return `filters[${index}].field must be a non-empty string`;
+  }
+
+  if (
+    typeof filter.operator !== `string` ||
+    !FILTER_OPERATORS.includes(filter.operator as FilterOperator)
+  ) {
+    return `filters[${index}].operator must be a supported filter operator`;
+  }
+
+  if (VALUES_ARRAY_OPERATORS.includes(filter.operator)) {
+    if (!Array.isArray(filter.values) || filter.values.length === 0) {
+      return `filters[${index}].values must be a non-empty array for operator "${filter.operator}"`;
+    }
+    return null;
+  }
+
+  if (VALUELESS_OPERATORS.includes(filter.operator)) {
+    return null;
+  }
+
+  if (filter.value === undefined || filter.value === null) {
+    return `filters[${index}].value is required for operator "${filter.operator}"`;
+  }
+
+  return null;
+}
+
+export function ValidateFilterParams(data: FilterParams): string | null {
+  if (!data || typeof data !== `object`) {
+    return `Filter params must be a valid object`;
+  }
+
+  if (!Array.isArray(data.filters)) {
+    return `filters must be an array`;
+  }
+
+  for (let index = 0; index < data.filters.length; index++) {
+    const filterError = validateFilterCondition(data.filters[index], index);
+    if (filterError) {
+      return filterError;
+    }
+  }
+
+  if (
+    data.logical_operator !== undefined &&
+    (typeof data.logical_operator !== `string` ||
+      !isFilterLogicalOperator(data.logical_operator))
+  ) {
+    return `logical_operator must be "and" or "or" if provided`;
+  }
+
+  if (data.sort_by !== undefined && typeof data.sort_by !== `string`) {
+    return `sort_by must be a string if provided`;
+  }
+
+  if (
+    data.sort_order !== undefined &&
+    (typeof data.sort_order !== `string` || !isFilterSortOrder(data.sort_order))
+  ) {
+    return `sort_order must be "asc" or "desc" if provided`;
+  }
+
+  if (
+    data.include_count !== undefined &&
+    typeof data.include_count !== `boolean`
+  ) {
+    return `include_count must be a boolean if provided`;
+  }
+
+  if (
+    data.limit !== undefined &&
+    (!Number.isInteger(data.limit) ||
+      data.limit < 1 ||
+      data.limit > MAX_FILTER_LIMIT)
+  ) {
+    return `limit must be an integer between 1 and 100 if provided`;
+  }
+
+  if (
+    data.offset !== undefined &&
+    (!Number.isInteger(data.offset) || data.offset < 0)
+  ) {
+    return `offset must be a non-negative integer if provided`;
   }
 
   return null;

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,3 +1,8 @@
+import {IdentityDataResponse} from "./identity";
+import {CreateLedgerResp} from "./ledger";
+import {CreateLedgerBalanceResp} from "./ledgerBalances";
+import {CreateTransactionResponse} from "./transactions";
+
 export interface SearchParams {
   q: string;
   query_by?: string;
@@ -155,3 +160,57 @@ export type SearchLedgerResponse = SearchResponse<SearchLedgerDocument>;
 export type SearchBalanceResponse = SearchResponse<SearchBalanceDocument>;
 export type SearchTransactionResponse =
   SearchResponse<SearchTransactionDocument>;
+
+/** Filter operators supported by `POST /{collection}/filter`. */
+export type FilterOperator =
+  | `eq`
+  | `ne`
+  | `gt`
+  | `gte`
+  | `lt`
+  | `lte`
+  | `in`
+  | `between`
+  | `like`
+  | `ilike`
+  | `isnull`
+  | `isnotnull`;
+
+export type FilterLogicalOperator = `and` | `or`;
+export type FilterSortOrder = `asc` | `desc`;
+
+/** Single filter condition in a DB filter request. */
+export interface FilterCondition {
+  field: string;
+  operator: FilterOperator;
+  value?: unknown;
+  values?: unknown[];
+}
+
+/** Request body for `POST /{collection}/filter` (Search via DB). */
+export interface FilterParams {
+  filters: FilterCondition[];
+  logical_operator?: FilterLogicalOperator;
+  sort_by?: string;
+  sort_order?: FilterSortOrder;
+  include_count?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/** Response from `POST /{collection}/filter`. */
+export interface FilterResponse<TRecord> {
+  data: TRecord[];
+  total_count?: number;
+}
+
+export type FilterRecordByCollection = {
+  ledgers: CreateLedgerResp<Record<string, unknown>>;
+  transactions: CreateTransactionResponse<Record<string, unknown>>;
+  balances: CreateLedgerBalanceResp<Record<string, unknown>>;
+  identities: IdentityDataResponse<Record<string, unknown>>;
+};
+
+export type FilterResponseByCollection = {
+  [K in SearchCollection]: FilterResponse<FilterRecordByCollection[K]>;
+};

--- a/tests/unit/blnk/endpoints/searchFilter.test.ts
+++ b/tests/unit/blnk/endpoints/searchFilter.test.ts
@@ -1,0 +1,114 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Search} from "../../../../src/blnk/endpoints/search";
+import {
+  createMockBlnkRequest,
+  createMockLogger,
+} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {FilterParams} from "../../../../src/types/search";
+
+tap.test(`Issue #33 — Search.filter`, async t => {
+  t.test(`filter forwards transactions collection`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const params: FilterParams = {
+      filters: [{field: `status`, operator: `eq`, value: `APPLIED`}],
+      logical_operator: `and`,
+      sort_by: `created_at`,
+      sort_order: `desc`,
+      include_count: true,
+      limit: 20,
+      offset: 0,
+    };
+
+    const response = await search.filter(params, `transactions`);
+
+    childTest.match(capturedRequest.args(), [
+      [`transactions/filter`, params, `POST`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`filter forwards ledgers collection`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const params: FilterParams = {
+      filters: [{field: `name`, operator: `like`, value: `%General%`}],
+    };
+
+    const response = await search.filter(params, `ledgers`);
+
+    childTest.match(capturedRequest.args(), [
+      [`ledgers/filter`, params, `POST`],
+    ]);
+    childTest.equal(response.status, 200);
+    childTest.end();
+  });
+
+  t.test(`filter rejects invalid collection`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.filter(
+      {filters: [{field: `status`, operator: `eq`, value: `APPLIED`}]},
+      `accounts` as `transactions`,
+    );
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.end();
+  });
+
+  t.test(`filter rejects missing filter value`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.filter(
+      {filters: [{field: `status`, operator: `eq`}]},
+      `transactions`,
+    );
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `filters[0].value is required for operator "eq"`,
+    );
+    childTest.end();
+  });
+
+  t.test(`filter rejects invalid limit`, async childTest => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = childTest.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.filter(
+      {
+        filters: [{field: `status`, operator: `eq`, value: `APPLIED`}],
+        limit: 500,
+      },
+      `transactions`,
+    );
+
+    childTest.match(capturedRequest.args(), []);
+    childTest.equal(response.status, 400);
+    childTest.equal(
+      response.message,
+      `limit must be an integer between 1 and 100 if provided`,
+    );
+    childTest.end();
+  });
+});

--- a/tests/unit/blnk/utils/filterValidators.test.ts
+++ b/tests/unit/blnk/utils/filterValidators.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateFilterParams} from "../../../../src/blnk/utils/validators/searchValidators";
+
+tap.test(`Issue #33 — filter validators`, t => {
+  t.test(`ValidateFilterParams accepts API-valid payload`, tt => {
+    tt.equal(
+      ValidateFilterParams({
+        filters: [
+          {field: `status`, operator: `eq`, value: `APPLIED`},
+          {field: `currency`, operator: `in`, values: [`USD`, `EUR`]},
+        ],
+        logical_operator: `and`,
+        sort_by: `created_at`,
+        sort_order: `desc`,
+        include_count: true,
+        limit: 20,
+        offset: 0,
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`ValidateFilterParams accepts valueless operators`, tt => {
+    tt.equal(
+      ValidateFilterParams({
+        filters: [{field: `identity_id`, operator: `isnull`}],
+      }),
+      null,
+    );
+    tt.end();
+  });
+
+  t.test(`ValidateFilterParams rejects missing values for in operator`, tt => {
+    tt.equal(
+      ValidateFilterParams({
+        filters: [{field: `currency`, operator: `in`}],
+      }),
+      `filters[0].values must be a non-empty array for operator "in"`,
+    );
+    tt.end();
+  });
+
+  t.test(`ValidateFilterParams rejects invalid logical_operator`, tt => {
+    tt.equal(
+      ValidateFilterParams({
+        filters: [{field: `status`, operator: `eq`, value: `APPLIED`}],
+        logical_operator: `xor` as `and`,
+      }),
+      `logical_operator must be "and" or "or" if provided`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `Search.filter(params, collection)` calling `POST /{collection}/filter` for `ledgers`, `balances`, `transactions`, and `identities`.
- Add `FilterParams`, `FilterCondition`, `FilterResponse<T>`, and per-collection `FilterRecordByCollection` types aligned with the [Search via DB reference](https://docs.blnkfinance.com/reference/search-db).
- Add `ValidateFilterParams` (operators, required values/`values`, limit 1–100, offset, logical/sort options).
- Add endpoint + validator unit tests and README Search section (Typesense vs DB filter endpoint map).

## Test plan
- [x] `npm run test:unit` (575 passing)
- [x] `npm run lint`
- [x] Postman **TS SDK (#33)** — `POST /transactions/filter` with `status=APPLIED`, asserts `data` array + `total_count`

Closes #33