### PR TITLE
Add Search.startReindex (POST /search/reindex) (closes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ Blnk supports two search modes on the `Search` service:
 |--------|----------|----------|
 | `Search.search(params, collection)` | `POST /search/{collection}` | Full-text search via Typesense |
 | `Search.filter(params, collection)` | `POST /{collection}/filter` | Structured DB filters (Core 0.13.2+) |
+| `Search.startReindex(options?)` | `POST /search/reindex` | Rebuild Typesense index from DB |
 
 Collections: `ledgers`, `balances`, `transactions`, `identities`.
 
@@ -726,6 +727,18 @@ const filtered = await Search.filter(
 ```
 
 See the [Search via DB reference](https://docs.blnkfinance.com/reference/search-db) for supported operators and fields.
+
+### Typesense reindex
+
+```typescript
+const { Search } = blnk;
+
+const reindex = await Search.startReindex({ batch_size: 1000 });
+// reindex.data?.message — "Reindex operation started"
+// reindex.data?.progress.status — "pending" | "in_progress" | "completed" | "failed"
+```
+
+See the [Start reindex reference](https://docs.blnkfinance.com/reference/start-reindex).
 
 ---
 

--- a/src/blnk/endpoints/search.ts
+++ b/src/blnk/endpoints/search.ts
@@ -12,12 +12,15 @@ import {
   SearchDocumentByCollection,
   SearchParams,
   SearchResponse,
+  StartReindexRequest,
+  StartReindexResponse,
 } from "../../types/search";
 import {HandleError} from "../utils/logger";
 import {
   ValidateFilterParams,
   ValidateSearchCollection,
   ValidateSearchParams,
+  ValidateStartReindexRequest,
 } from "../utils/validators/searchValidators";
 
 /**
@@ -99,6 +102,41 @@ export class Search {
         this.logger,
         this.formatResponse,
         this.filter.name,
+      );
+    }
+  }
+
+  /**
+   * Starts a Typesense reindex from the database.
+   *
+   * @see https://docs.blnkfinance.com/reference/start-reindex
+   */
+  async startReindex(options?: StartReindexRequest) {
+    try {
+      if (options !== undefined) {
+        const paramsError = ValidateStartReindexRequest(options);
+        if (paramsError) {
+          return this.formatResponse(400, paramsError, null);
+        }
+      }
+
+      const body: StartReindexRequest =
+        options?.batch_size !== undefined
+          ? {batch_size: options.batch_size}
+          : {};
+
+      const response = await this.request<
+        StartReindexRequest,
+        StartReindexResponse
+      >(`search/reindex`, body, `POST`);
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.startReindex.name,
       );
     }
   }

--- a/src/blnk/utils/validators/searchValidators.ts
+++ b/src/blnk/utils/validators/searchValidators.ts
@@ -6,6 +6,7 @@ import {
   FilterSortOrder,
   SearchCollection,
   SearchParams,
+  StartReindexRequest,
 } from "../../../types/search";
 
 const SEARCH_COLLECTIONS: SearchCollection[] = [
@@ -187,6 +188,23 @@ export function ValidateFilterParams(data: FilterParams): string | null {
     (!Number.isInteger(data.offset) || data.offset < 0)
   ) {
     return `offset must be a non-negative integer if provided`;
+  }
+
+  return null;
+}
+
+export function ValidateStartReindexRequest(
+  data: StartReindexRequest,
+): string | null {
+  if (!data || typeof data !== `object`) {
+    return `Reindex options must be a valid object`;
+  }
+
+  if (
+    data.batch_size !== undefined &&
+    (!Number.isInteger(data.batch_size) || data.batch_size < 1)
+  ) {
+    return `batch_size must be a positive integer if provided`;
   }
 
   return null;

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -214,3 +214,25 @@ export type FilterRecordByCollection = {
 export type FilterResponseByCollection = {
   [K in SearchCollection]: FilterResponse<FilterRecordByCollection[K]>;
 };
+
+/** Optional body for `POST /search/reindex`. */
+export interface StartReindexRequest {
+  batch_size?: number;
+}
+
+/** Progress snapshot returned by reindex endpoints. */
+export interface ReindexProgress {
+  status: string;
+  phase: string;
+  total_records: number;
+  processed_records: number;
+  started_at: string;
+  completed_at?: string;
+  errors?: string[];
+}
+
+/** Response from `POST /search/reindex`. */
+export interface StartReindexResponse {
+  message: string;
+  progress: ReindexProgress;
+}

--- a/tests/unit/blnk/endpoints/searchStartReindex.test.ts
+++ b/tests/unit/blnk/endpoints/searchStartReindex.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Search} from "../../../../src/blnk/endpoints/search";
+import {
+  createMockBlnkRequest,
+  createMockLogger,
+} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+
+tap.test(`Issue #34 — Search.startReindex`, async t => {
+  t.test(`startReindex posts to search/reindex with empty body`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 202);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.startReindex();
+
+    tt.match(capturedRequest.args(), [[`search/reindex`, {}, `POST`]]);
+    tt.equal(response.status, 202);
+    tt.end();
+  });
+
+  t.test(`startReindex forwards batch_size`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 202);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.startReindex({batch_size: 500});
+
+    tt.match(capturedRequest.args(), [
+      [`search/reindex`, {batch_size: 500}, `POST`],
+    ]);
+    tt.equal(response.status, 202);
+    tt.end();
+  });
+
+  t.test(`startReindex rejects invalid batch_size`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = createMockBlnkRequest(true);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.startReindex({batch_size: 0});
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(
+      response.message,
+      `batch_size must be a positive integer if provided`,
+    );
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/startReindexValidators.test.ts
+++ b/tests/unit/blnk/utils/startReindexValidators.test.ts
@@ -1,0 +1,25 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateStartReindexRequest} from "../../../../src/blnk/utils/validators/searchValidators";
+
+tap.test(`Issue #34 — start reindex validators`, t => {
+  t.test(`ValidateStartReindexRequest accepts empty options`, tt => {
+    tt.equal(ValidateStartReindexRequest({}), null);
+    tt.end();
+  });
+
+  t.test(`ValidateStartReindexRequest accepts positive batch_size`, tt => {
+    tt.equal(ValidateStartReindexRequest({batch_size: 1000}), null);
+    tt.end();
+  });
+
+  t.test(`ValidateStartReindexRequest rejects non-integer batch_size`, tt => {
+    tt.equal(
+      ValidateStartReindexRequest({batch_size: 1.5}),
+      `batch_size must be a positive integer if provided`,
+    );
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `Search.startReindex(options?)` calling `POST /search/reindex` with optional `{ batch_size }`.
- Add `StartReindexRequest`, `ReindexProgress`, and `StartReindexResponse` types aligned with the [Start reindex reference](https://docs.blnkfinance.com/reference/start-reindex) and Core response (`message` + `progress`, HTTP 202).
- Add `ValidateStartReindexRequest` (positive integer `batch_size` when provided).
- Add endpoint + validator unit tests and README Search endpoint map entry.

## Test plan
- [x] `npm run test:unit` (587 passing)
- [x] `npm run lint`
- [x] Postman **TS SDK (#34)** — `POST /search/reindex`, expects 202 with `message` + `progress` fields

Closes #34