### PR TITLE
Add Search.getReindexStatus (GET /search/reindex) (closes #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Blnk supports two search modes on the `Search` service:
 | `Search.search(params, collection)` | `POST /search/{collection}` | Full-text search via Typesense |
 | `Search.filter(params, collection)` | `POST /{collection}/filter` | Structured DB filters (Core 0.13.2+) |
 | `Search.startReindex(options?)` | `POST /search/reindex` | Rebuild Typesense index from DB |
+| `Search.getReindexStatus()` | `GET /search/reindex` | Poll reindex progress |
 
 Collections: `ledgers`, `balances`, `transactions`, `identities`.
 
@@ -739,6 +740,16 @@ const reindex = await Search.startReindex({ batch_size: 1000 });
 ```
 
 See the [Start reindex reference](https://docs.blnkfinance.com/reference/start-reindex).
+
+Poll progress after starting a reindex:
+
+```typescript
+const status = await Search.getReindexStatus();
+// status.data?.status — "in_progress" | "completed" | "failed"
+// status.data?.phase — e.g. "indexing_transactions" or "done"
+```
+
+See the [Get reindex status reference](https://docs.blnkfinance.com/reference/get-reindex).
 
 ---
 

--- a/src/blnk/endpoints/search.ts
+++ b/src/blnk/endpoints/search.ts
@@ -12,6 +12,7 @@ import {
   SearchDocumentByCollection,
   SearchParams,
   SearchResponse,
+  GetReindexStatusResponse,
   StartReindexRequest,
   StartReindexResponse,
 } from "../../types/search";
@@ -137,6 +138,30 @@ export class Search {
         this.logger,
         this.formatResponse,
         this.startReindex.name,
+      );
+    }
+  }
+
+  /**
+   * Polls Typesense reindex progress.
+   *
+   * @see https://docs.blnkfinance.com/reference/get-reindex
+   */
+  async getReindexStatus() {
+    try {
+      const response = await this.request<undefined, GetReindexStatusResponse>(
+        `search/reindex`,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getReindexStatus.name,
       );
     }
   }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -236,3 +236,6 @@ export interface StartReindexResponse {
   message: string;
   progress: ReindexProgress;
 }
+
+/** Response from `GET /search/reindex`. */
+export type GetReindexStatusResponse = ReindexProgress;

--- a/tests/unit/blnk/endpoints/searchGetReindexStatus.test.ts
+++ b/tests/unit/blnk/endpoints/searchGetReindexStatus.test.ts
@@ -1,0 +1,59 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Search} from "../../../../src/blnk/endpoints/search";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {ReindexProgress} from "../../../../src/types/search";
+
+tap.test(`Issue #35 — Search.getReindexStatus`, async t => {
+  t.test(`getReindexStatus GETs search/reindex`, async tt => {
+    const mockLogger = createMockLogger();
+    const progress: ReindexProgress = {
+      status: `in_progress`,
+      phase: `indexing_transactions`,
+      total_records: 100,
+      processed_records: 50,
+      started_at: `2026-06-12T02:03:08.81867638Z`,
+    };
+    const thirdPartyRequest = async <T, R>(
+      endpoint: string,
+      data: T,
+      method: `POST` | `GET` | `PUT` | `DELETE`,
+    ) => ({
+      status: 200,
+      message: `Success`,
+      data: progress as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.getReindexStatus();
+
+    tt.match(capturedRequest.args(), [[`search/reindex`, undefined, `GET`]]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.status, `in_progress`);
+    tt.equal(response.data?.phase, `indexing_transactions`);
+    tt.end();
+  });
+
+  t.test(`getReindexStatus forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <T, R>(
+      endpoint: string,
+      data: T,
+      method: `POST` | `GET` | `PUT` | `DELETE`,
+    ) => ({
+      status: 404,
+      message: `No reindex operation has been started`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const search = new Search(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await search.getReindexStatus();
+
+    tt.match(capturedRequest.args(), [[`search/reindex`, undefined, `GET`]]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Search.getReindexStatus()` calling `GET /search/reindex` to poll Typesense reindex progress.
- Reuse `ReindexProgress` from #34 and export `GetReindexStatusResponse` alias per reference.
- Add endpoint unit tests (success + 404 passthrough) and README Search endpoint map entry.

## Test plan
- [x] `npm run test:unit` (594 passing)
- [x] `npm run lint`
- [x] Postman **TS SDK (#35)** — `GET /search/reindex`, expects 200 with `status`, `phase`, `total_records`, `processed_records`, `started_at`

Closes #35