### PR TITLE
Add Reconciliation.runInstant (POST /reconciliation/start-instant) (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,43 @@ See the [Get reindex status reference](https://docs.blnkfinance.com/reference/ge
 
 ---
 
+## Reconciliation
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `Reconciliation.upload(file, source)` | `POST /reconciliation/upload` | Upload external data file |
+| `Reconciliation.createMatchingRule(data)` | `POST /reconciliation/matching-rules` | Define match criteria |
+| `Reconciliation.run(data)` | `POST /reconciliation/start` | Start batch reconciliation from upload |
+| `Reconciliation.runInstant(data)` | `POST /reconciliation/start-instant` | Reconcile inline external transactions |
+
+### Instant reconciliation
+
+```typescript
+const { Reconciliation } = blnk;
+
+const instant = await Reconciliation.runInstant({
+  external_transactions: [
+    {
+      id: 'txn_1',
+      amount: 5.49,
+      reference: 'INV-2023-002',
+      currency: 'GBP',
+      description: 'Card payment',
+      date: '2024-11-15T14:25:30Z',
+      source: 'bank-api',
+    },
+  ],
+  strategy: 'one_to_one',
+  dry_run: true,
+  matching_rule_ids: ['rule_abc123'],
+});
+// instant.data?.reconciliation_id — reconciliation run ID
+```
+
+See the [Instant reconciliation reference](https://docs.blnkfinance.com/reference/instant-reconciliation).
+
+---
+
 ## Additional Resources
 
 For more examples and advanced use cases, please refer to the [Examples Code](https://github.com/blnkfinance/blnk-ts/tree/main/examples).

--- a/src/blnk/endpoints/reconciliation.ts
+++ b/src/blnk/endpoints/reconciliation.ts
@@ -6,10 +6,15 @@ import fs from "fs";
 import {
   Matcher,
   ReconciliationUploadResp,
+  RunInstantReconData,
+  RunInstantReconResp,
   RunReconData,
   RunReconResp,
 } from "../../types/reconciliation";
-import {ValidateMatcher} from "../utils/validators/reconciliationValidator";
+import {
+  ValidateMatcher,
+  ValidateRunInstantReconData,
+} from "../utils/validators/reconciliationValidator";
 import FormData1 from "form-data";
 
 /**
@@ -181,6 +186,34 @@ export class Reconciliation {
         this.logger,
         this.formatResponse,
         this.run.name,
+      );
+    }
+  }
+
+  /**
+   * Starts instant reconciliation with inline external transactions (no file upload).
+   *
+   * @see https://docs.blnkfinance.com/reference/instant-reconciliation
+   */
+  async runInstant(data: RunInstantReconData) {
+    try {
+      const validatorResponse = await ValidateRunInstantReconData(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<
+        RunInstantReconData,
+        RunInstantReconResp
+      >(`reconciliation/start-instant`, data, `POST`);
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.runInstant.name,
       );
     }
   }

--- a/src/blnk/utils/validators/reconciliationValidator.ts
+++ b/src/blnk/utils/validators/reconciliationValidator.ts
@@ -1,10 +1,15 @@
 import {
   Criteria,
   CriteriaField,
+  ExternalTransaction,
   Matcher,
   Operator,
+  RunInstantReconData,
+  Strategy,
 } from "../../../types/reconciliation";
 import {IsValidArray, IsValidNumber, IsValidString} from "../stringUtils";
+
+const MAX_INSTANT_RECON_ITEMS = 10000;
 
 export function ValidateMatcher(data: Matcher): string | null {
   // Validate if data is an object
@@ -50,3 +55,75 @@ const isValidCriteria = (criteria: Criteria) =>
   isValidOperator(criteria.operator) &&
   (criteria.allowable_drift === undefined ||
     IsValidNumber(criteria.allowable_drift));
+
+const isValidStrategy = (strategy: Strategy) =>
+  [`one_to_one`, `one_to_many`, `many_to_one`].includes(strategy);
+
+const isValidExternalTransaction = (txn: ExternalTransaction) =>
+  txn &&
+  typeof txn === `object` &&
+  IsValidString(txn.id) &&
+  IsValidNumber(txn.amount) &&
+  IsValidString(txn.reference) &&
+  IsValidString(txn.currency) &&
+  IsValidString(txn.description) &&
+  IsValidString(txn.date) &&
+  IsValidString(txn.source);
+
+export function ValidateRunInstantReconData(
+  data: RunInstantReconData,
+): string | null {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type RunInstantReconData`;
+  }
+
+  if (
+    !IsValidArray(data.external_transactions) ||
+    data.external_transactions.length === 0
+  ) {
+    return `external_transactions must be a non-empty array`;
+  }
+
+  if (data.external_transactions.length > MAX_INSTANT_RECON_ITEMS) {
+    return `too many external_transactions; max is ${MAX_INSTANT_RECON_ITEMS}`;
+  }
+
+  for (const txn of data.external_transactions) {
+    if (!isValidExternalTransaction(txn)) {
+      return `Each external transaction must include id, amount, reference, currency, description, date, and source`;
+    }
+  }
+
+  if (
+    !IsValidString(data.strategy) ||
+    !isValidStrategy(data.strategy as Strategy)
+  ) {
+    return `strategy must be one of: one_to_one, one_to_many, many_to_one`;
+  }
+
+  if (
+    !IsValidArray(data.matching_rule_ids) ||
+    data.matching_rule_ids.length === 0
+  ) {
+    return `matching_rule_ids must be a non-empty array`;
+  }
+
+  for (const ruleId of data.matching_rule_ids) {
+    if (!IsValidString(ruleId)) {
+      return `Each matching_rule_id must be a valid string`;
+    }
+  }
+
+  if (data.dry_run !== undefined && typeof data.dry_run !== `boolean`) {
+    return `dry_run must be a boolean`;
+  }
+
+  if (
+    data.grouping_criteria !== undefined &&
+    !IsValidString(data.grouping_criteria)
+  ) {
+    return `grouping_criteria must be a valid string`;
+  }
+
+  return null;
+}

--- a/src/types/reconciliation.ts
+++ b/src/types/reconciliation.ts
@@ -25,7 +25,7 @@ export interface Matcher {
   criteria: Criteria[];
 }
 
-type Strategy = `one_to_one` | `one_to_many` | `many_to_one`;
+export type Strategy = `one_to_one` | `one_to_many` | `many_to_one`;
 
 export interface RunReconData {
   upload_id: string;
@@ -39,4 +39,26 @@ export interface RunReconResp extends Matcher {
   rule_id: string;
   created_at: string;
   updated_at: string;
+}
+
+export interface ExternalTransaction {
+  id: string;
+  amount: number;
+  reference: string;
+  currency: string;
+  description: string;
+  date: string;
+  source: string;
+}
+
+export interface RunInstantReconData {
+  external_transactions: ExternalTransaction[];
+  strategy: Strategy;
+  dry_run?: boolean;
+  grouping_criteria?: string;
+  matching_rule_ids: string[];
+}
+
+export interface RunInstantReconResp {
+  reconciliation_id: string;
 }

--- a/tests/unit/blnk/endpoints/reconciliationRunInstant.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliationRunInstant.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {RunInstantReconData} from "../../../../src/types/reconciliation";
+
+const validData: RunInstantReconData = {
+  external_transactions: [
+    {
+      id: `txn_1`,
+      amount: 5.49,
+      reference: `INV-2023-002`,
+      currency: `GBP`,
+      description: `Card payment`,
+      date: `2024-11-15T14:25:30Z`,
+      source: `bank-api`,
+    },
+  ],
+  strategy: `one_to_one`,
+  dry_run: true,
+  matching_rule_ids: [`rule_abc123`],
+};
+
+tap.test(`Issue #18 — Reconciliation.runInstant`, async t => {
+  t.test(`runInstant POSTs reconciliation/start-instant`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <T, R>(
+      endpoint: string,
+      data: T,
+      method: `POST` | `GET` | `PUT` | `DELETE`,
+    ) => ({
+      status: 200,
+      message: `Success`,
+      data: {reconciliation_id: `rec_test_123`} as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.runInstant(validData);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/start-instant`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.reconciliation_id, `rec_test_123`);
+    tt.end();
+  });
+
+  t.test(`runInstant returns 400 for invalid payload`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <T, R>() => ({
+      status: 200,
+      message: `Success`,
+      data: {reconciliation_id: `rec_test_123`} as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.runInstant({
+      ...validData,
+      external_transactions: [],
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /external_transactions/);
+    tt.end();
+  });
+
+  t.test(`runInstant forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <T, R>() => ({
+      status: 500,
+      message: `Failed to start instant reconciliation`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.runInstant(validData);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/start-instant`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 500);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/runInstantValidators.test.ts
+++ b/tests/unit/blnk/utils/runInstantValidators.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateRunInstantReconData} from "../../../../src/blnk/utils/validators/reconciliationValidator";
+import {RunInstantReconData} from "../../../../src/types/reconciliation";
+
+const validData: RunInstantReconData = {
+  external_transactions: [
+    {
+      id: `txn_1`,
+      amount: 5.49,
+      reference: `INV-2023-002`,
+      currency: `GBP`,
+      description: `Card payment`,
+      date: `2024-11-15T14:25:30Z`,
+      source: `bank-api`,
+    },
+  ],
+  strategy: `one_to_one`,
+  matching_rule_ids: [`rule_abc123`],
+};
+
+tap.test(`ValidateRunInstantReconData`, async t => {
+  t.test(`accepts valid payload`, tt => {
+    tt.equal(ValidateRunInstantReconData(validData), null);
+    tt.end();
+  });
+
+  t.test(`rejects empty external_transactions`, tt => {
+    tt.match(
+      ValidateRunInstantReconData({
+        ...validData,
+        external_transactions: [],
+      }),
+      /external_transactions/,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects too many external_transactions`, tt => {
+    const txns = Array.from({length: 10001}, (_, i) => ({
+      id: `txn_${i}`,
+      amount: 1,
+      reference: `ref_${i}`,
+      currency: `USD`,
+      description: `desc`,
+      date: `2024-11-15T14:25:30Z`,
+      source: `bank-api`,
+    }));
+    tt.match(
+      ValidateRunInstantReconData({
+        ...validData,
+        external_transactions: txns,
+      }),
+      /too many external_transactions/,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects invalid strategy`, tt => {
+    tt.match(
+      ValidateRunInstantReconData({
+        ...validData,
+        strategy: `invalid` as RunInstantReconData[`strategy`],
+      }),
+      /strategy/,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects empty matching_rule_ids`, tt => {
+    tt.match(
+      ValidateRunInstantReconData({
+        ...validData,
+        matching_rule_ids: [],
+      }),
+      /matching_rule_ids/,
+    );
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Reconciliation.runInstant(data)` calling `POST /reconciliation/start-instant` with inline external transactions.
- Add `ExternalTransaction`, `RunInstantReconData`, and `RunInstantReconResp` types aligned with the [Instant reconciliation reference](https://docs.blnkfinance.com/reference/instant-reconciliation).
- Add `ValidateRunInstantReconData` (non-empty transactions, max 10,000 items, strategy/matching-rule checks).
- Add endpoint + validator unit tests and README Reconciliation endpoint map entry.

## Test plan
- [x] `npm run test:unit` (608 passing)
- [x] `npm run lint`
- [x] Postman **TS SDK (#18)** — `POST /reconciliation/start-instant` with `dry_run: true`, expects 200 with `reconciliation_id`

Closes #18

Made with [Cursor](https://cursor.com)