### PR TITLE
Add Reconciliation.get (GET /reconciliation/{reconciliation_id}) (closes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,19 @@ See the [Get reindex status reference](https://docs.blnkfinance.com/reference/ge
 | `Reconciliation.createMatchingRule(data)` | `POST /reconciliation/matching-rules` | Define match criteria |
 | `Reconciliation.run(data)` | `POST /reconciliation/start` | Start batch reconciliation from upload |
 | `Reconciliation.runInstant(data)` | `POST /reconciliation/start-instant` | Reconcile inline external transactions |
+| `Reconciliation.get(id)` | `GET /reconciliation/{reconciliation_id}` | View reconciliation status and counts |
+
+### Get reconciliation status
+
+```typescript
+const { Reconciliation } = blnk;
+
+const status = await Reconciliation.get('recon_3803ea0d-28b4-4c73-a36b-5a9eb7a3edfd');
+// status.data?.status — e.g. started, in_progress, completed, failed
+// status.data?.matched_transactions, unmatched_transactions
+```
+
+See the [View reconciliation details reference](https://docs.blnkfinance.com/reference/get-reconciliations).
 
 ### Instant reconciliation
 

--- a/src/blnk/endpoints/reconciliation.ts
+++ b/src/blnk/endpoints/reconciliation.ts
@@ -5,6 +5,7 @@ import {HandleError} from "../utils/logger";
 import fs from "fs";
 import {
   Matcher,
+  ReconciliationResp,
   ReconciliationUploadResp,
   RunInstantReconData,
   RunInstantReconResp,
@@ -214,6 +215,34 @@ export class Reconciliation {
         this.logger,
         this.formatResponse,
         this.runInstant.name,
+      );
+    }
+  }
+
+  /**
+   * Retrieves a reconciliation by ID.
+   *
+   * @see https://docs.blnkfinance.com/reference/get-reconciliations
+   */
+  async get(reconciliationId: string) {
+    try {
+      if (!reconciliationId) {
+        return this.formatResponse(400, `reconciliation id is required`, null);
+      }
+
+      const response = await this.request<undefined, ReconciliationResp>(
+        `reconciliation/${reconciliationId}`,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.get.name,
       );
     }
   }

--- a/src/types/reconciliation.ts
+++ b/src/types/reconciliation.ts
@@ -62,3 +62,14 @@ export interface RunInstantReconData {
 export interface RunInstantReconResp {
   reconciliation_id: string;
 }
+
+export interface ReconciliationResp {
+  reconciliation_id: string;
+  upload_id: string;
+  status: string;
+  matched_transactions: number;
+  unmatched_transactions: number;
+  is_dry_run: boolean;
+  started_at: string;
+  completed_at: string | null;
+}

--- a/tests/unit/blnk/endpoints/reconciliationGet.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliationGet.test.ts
@@ -1,0 +1,89 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {ReconciliationResp} from "../../../../src/types/reconciliation";
+
+const mockReconciliation: ReconciliationResp = {
+  reconciliation_id: `recon_test_123`,
+  upload_id: `instant_abc`,
+  status: `completed`,
+  matched_transactions: 2,
+  unmatched_transactions: 1,
+  is_dry_run: true,
+  started_at: `2026-06-12T04:23:48.196087Z`,
+  completed_at: `2026-06-12T04:23:49.196087Z`,
+};
+
+tap.test(`Issue #19 — Reconciliation.get`, async t => {
+  t.test(`get calls reconciliation/{id}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockReconciliation as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.get(`recon_test_123`);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/recon_test_123`, undefined, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.reconciliation_id, `recon_test_123`);
+    tt.equal(response.data?.status, `completed`);
+    tt.end();
+  });
+
+  t.test(`get rejects empty reconciliation id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockReconciliation as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.get(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `reconciliation id is required`);
+    tt.end();
+  });
+
+  t.test(`get forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Reconciliation not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.get(`recon_missing`);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/recon_missing`, undefined, `GET`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `Reconciliation.get(reconciliationId)` calling `GET /reconciliation/{reconciliation_id}`
- Introduces `ReconciliationResp` type aligned with Core response fields (`reconciliation_id`, `upload_id`, `status`, match counts, `is_dry_run`, `started_at`, `completed_at`)
- Client-side validation rejects empty reconciliation id before the HTTP call
- Unit tests for success path, empty id rejection, and API error forwarding
- README endpoint map + usage example

## Acceptance criteria
- [x] Add `Reconciliation.get` calling `/reconciliation/{reconciliation_id}`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] Example in README

## Test plan
- [x] `npm run test:unit` — 618 passing
- [x] `npm run lint` — clean (0 errors)
- [ ] Postman **TS SDK (#19)** folder in *Blnk SDK Issues — Local Core Tests (fixed)* — self-setup via instant recon prerequest