### PR TITLE
Add Reconciliation.updateMatchingRule (PUT /reconciliation/matching-rules/{rule_id}) (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,9 +759,28 @@ See the [Get reindex status reference](https://docs.blnkfinance.com/reference/ge
 |--------|----------|----------|
 | `Reconciliation.upload(file, source)` | `POST /reconciliation/upload` | Upload external data file |
 | `Reconciliation.createMatchingRule(data)` | `POST /reconciliation/matching-rules` | Define match criteria |
+| `Reconciliation.updateMatchingRule(id, data)` | `PUT /reconciliation/matching-rules/{rule_id}` | Update an existing matching rule |
 | `Reconciliation.run(data)` | `POST /reconciliation/start` | Start batch reconciliation from upload |
 | `Reconciliation.runInstant(data)` | `POST /reconciliation/start-instant` | Reconcile inline external transactions |
 | `Reconciliation.get(id)` | `GET /reconciliation/{reconciliation_id}` | View reconciliation status and counts |
+
+### Update a matching rule
+
+```typescript
+const { Reconciliation } = blnk;
+
+const updated = await Reconciliation.updateMatchingRule('rule_abc123', {
+  name: 'Updated matcher',
+  description: 'Amount with 2% drift matcher',
+  criteria: [
+    { field: 'amount', operator: 'equals', allowable_drift: 0.02 },
+    { field: 'currency', operator: 'equals' },
+  ],
+});
+// updated.data?.rule_id, updated.data?.updated_at
+```
+
+See the [Update matching rule reference](https://docs.blnkfinance.com/reference/update-matching-rule).
 
 ### Get reconciliation status
 

--- a/src/blnk/endpoints/reconciliation.ts
+++ b/src/blnk/endpoints/reconciliation.ts
@@ -156,6 +156,39 @@ export class Reconciliation {
   }
 
   /**
+   * Updates an existing matching rule.
+   *
+   * @see https://docs.blnkfinance.com/reference/update-matching-rule
+   */
+  async updateMatchingRule(ruleId: string, data: Matcher) {
+    try {
+      if (!ruleId) {
+        return this.formatResponse(400, `matching rule id is required`, null);
+      }
+
+      const validatorResponse = ValidateMatcher(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<Matcher, RunReconResp>(
+        `reconciliation/matching-rules/${ruleId}`,
+        data,
+        `PUT`,
+      );
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.updateMatchingRule.name,
+      );
+    }
+  }
+
+  /**
    * Asynchronously runs a reconciliation process with the provided data.
    * see @link https://docs.blnkfinance.com/reconciliations/strategies for more details.
    *

--- a/tests/unit/blnk/endpoints/reconciliationUpdateMatchingRule.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliationUpdateMatchingRule.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {Matcher, RunReconResp} from "../../../../src/types/reconciliation";
+
+const validData: Matcher = {
+  name: `Updated matcher`,
+  description: `Amount with 2% drift matcher`,
+  criteria: [
+    {field: `amount`, operator: `equals`, allowable_drift: 0.02},
+    {field: `currency`, operator: `equals`},
+  ],
+};
+
+const mockResponse: RunReconResp = {
+  ...validData,
+  rule_id: `rule_test_123`,
+  created_at: `2026-06-12T04:31:55.613241Z`,
+  updated_at: `2026-06-12T04:31:55.715443261Z`,
+};
+
+tap.test(`Issue #20 — Reconciliation.updateMatchingRule`, async t => {
+  t.test(
+    `updateMatchingRule PUTs reconciliation/matching-rules/{id}`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: mockResponse as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const reconciliation = new Reconciliation(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const response = await reconciliation.updateMatchingRule(
+        `rule_test_123`,
+        validData,
+      );
+
+      tt.match(capturedRequest.args(), [
+        [`reconciliation/matching-rules/rule_test_123`, validData, `PUT`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.equal(response.data?.rule_id, `rule_test_123`);
+      tt.equal(response.data?.name, `Updated matcher`);
+      tt.end();
+    },
+  );
+
+  t.test(`updateMatchingRule rejects empty rule id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.updateMatchingRule(``, validData);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `matching rule id is required`);
+    tt.end();
+  });
+
+  t.test(`updateMatchingRule returns 400 for invalid payload`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.updateMatchingRule(`rule_test_123`, {
+      ...validData,
+      criteria: [
+        {
+          field: `invalid` as Matcher[`criteria`][0][`field`],
+          operator: `equals`,
+        },
+      ],
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /criterion|criteria/i);
+    tt.end();
+  });
+
+  t.test(`updateMatchingRule forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Matching rule not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.updateMatchingRule(
+      `rule_missing`,
+      validData,
+    );
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/matching-rules/rule_missing`, validData, `PUT`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `Reconciliation.updateMatchingRule(ruleId, data)` calling `PUT /reconciliation/matching-rules/{rule_id}`
- Reuses existing `Matcher` request type and `RunReconResp` response type (aligned with Core)
- Client-side validation via `ValidateMatcher` plus empty rule id check
- Unit tests for success path, empty id, invalid criteria, and API error forwarding
- README endpoint map + usage example

## Acceptance criteria
- [x] Add `Reconciliation.updateMatchingRule` calling `/reconciliation/matching-rules/{rule_id}`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] Example in README

## Test plan
- [x] `npm run test:unit` — 631 passing
- [x] `npm run lint` — 0 errors
- [ ] Postman **TS SDK (#20)** folder in *Blnk SDK Issues — Local Core Tests (fixed)* — self-setup creates rule, then PUT updates it