### PR TITLE
Add Reconciliation.deleteMatchingRule (DELETE /reconciliation/matching-rules/{rule_id}) (closes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ See the [Get reindex status reference](https://docs.blnkfinance.com/reference/ge
 | `Reconciliation.upload(file, source)` | `POST /reconciliation/upload` | Upload external data file |
 | `Reconciliation.createMatchingRule(data)` | `POST /reconciliation/matching-rules` | Define match criteria |
 | `Reconciliation.updateMatchingRule(id, data)` | `PUT /reconciliation/matching-rules/{rule_id}` | Update an existing matching rule |
+| `Reconciliation.deleteMatchingRule(id)` | `DELETE /reconciliation/matching-rules/{rule_id}` | Remove a matching rule |
 | `Reconciliation.run(data)` | `POST /reconciliation/start` | Start batch reconciliation from upload |
 | `Reconciliation.runInstant(data)` | `POST /reconciliation/start-instant` | Reconcile inline external transactions |
 | `Reconciliation.get(id)` | `GET /reconciliation/{reconciliation_id}` | View reconciliation status and counts |
@@ -781,6 +782,17 @@ const updated = await Reconciliation.updateMatchingRule('rule_abc123', {
 ```
 
 See the [Update matching rule reference](https://docs.blnkfinance.com/reference/update-matching-rule).
+
+### Delete a matching rule
+
+```typescript
+const { Reconciliation } = blnk;
+
+const deleted = await Reconciliation.deleteMatchingRule('rule_abc123');
+// deleted.data?.message — "Matching rule deleted successfully"
+```
+
+See the [Delete matching rule reference](https://docs.blnkfinance.com/reference/delete-matching-rule).
 
 ### Get reconciliation status
 

--- a/src/blnk/endpoints/reconciliation.ts
+++ b/src/blnk/endpoints/reconciliation.ts
@@ -4,6 +4,7 @@ import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {HandleError} from "../utils/logger";
 import fs from "fs";
 import {
+  DeleteMatchingRuleResp,
   Matcher,
   ReconciliationResp,
   ReconciliationUploadResp,
@@ -184,6 +185,34 @@ export class Reconciliation {
         this.logger,
         this.formatResponse,
         this.updateMatchingRule.name,
+      );
+    }
+  }
+
+  /**
+   * Deletes a matching rule by ID.
+   *
+   * @see https://docs.blnkfinance.com/reference/delete-matching-rule
+   */
+  async deleteMatchingRule(ruleId: string) {
+    try {
+      if (!ruleId) {
+        return this.formatResponse(400, `matching rule id is required`, null);
+      }
+
+      const response = await this.request<undefined, DeleteMatchingRuleResp>(
+        `reconciliation/matching-rules/${ruleId}`,
+        undefined,
+        `DELETE`,
+      );
+
+      return response;
+    } catch (error) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.deleteMatchingRule.name,
       );
     }
   }

--- a/src/types/reconciliation.ts
+++ b/src/types/reconciliation.ts
@@ -63,6 +63,10 @@ export interface RunInstantReconResp {
   reconciliation_id: string;
 }
 
+export interface DeleteMatchingRuleResp {
+  message: string;
+}
+
 export interface ReconciliationResp {
   reconciliation_id: string;
   upload_id: string;

--- a/tests/unit/blnk/endpoints/reconciliationDeleteMatchingRule.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliationDeleteMatchingRule.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {DeleteMatchingRuleResp} from "../../../../src/types/reconciliation";
+
+const mockResponse: DeleteMatchingRuleResp = {
+  message: `Matching rule deleted successfully`,
+};
+
+tap.test(`Issue #21 — Reconciliation.deleteMatchingRule`, async t => {
+  t.test(
+    `deleteMatchingRule DELETEs reconciliation/matching-rules/{id}`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: mockResponse as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const reconciliation = new Reconciliation(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const response = await reconciliation.deleteMatchingRule(`rule_test_123`);
+
+      tt.match(capturedRequest.args(), [
+        [`reconciliation/matching-rules/rule_test_123`, undefined, `DELETE`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.equal(response.data?.message, `Matching rule deleted successfully`);
+      tt.end();
+    },
+  );
+
+  t.test(`deleteMatchingRule rejects empty rule id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.deleteMatchingRule(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `matching rule id is required`);
+    tt.end();
+  });
+
+  t.test(`deleteMatchingRule forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Matching rule not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.deleteMatchingRule(`rule_missing`);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/matching-rules/rule_missing`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `Reconciliation.deleteMatchingRule(ruleId)` calling `DELETE /reconciliation/matching-rules/{rule_id}`
- Introduces `DeleteMatchingRuleResp` type (`{ message: string }`) aligned with Core
- Client-side validation rejects empty rule id before the HTTP call
- Unit tests for success path, empty id rejection, and API error forwarding
- README endpoint map + usage example

## Acceptance criteria
- [x] Add `Reconciliation.deleteMatchingRule` calling `/reconciliation/matching-rules/{rule_id}`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] Example in README

## Test plan
- [x] `npm run test:unit` — 640 passing
- [x] `npm run lint` — 0 errors
- [ ] Postman **TS SDK (#21)** folder in *Blnk SDK Issues — Local Core Tests (fixed)* — self-setup creates rule, then DELETE removes it