### PR TITLE
Add Metadata.update (POST /{id}/metadata) (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,30 @@ See the [Instant reconciliation reference](https://docs.blnkfinance.com/referenc
 
 ---
 
+## Metadata
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `Metadata.update(id, data)` | `POST /{id}/metadata` | Add or update metadata on a ledger, transaction, balance, or identity |
+
+### Update metadata
+
+```typescript
+const { Metadata } = blnk;
+
+const updated = await Metadata.update('ldg_073f7ffe-9dfd-42ce-aa50-d1dca1788adc', {
+  meta_data: {
+    project_owner: 'Acme LLC',
+    update_status: 'Approved',
+  },
+});
+// updated.data?.meta_data — merged metadata from Core
+```
+
+See the [Update metadata reference](https://docs.blnkfinance.com/reference/update-metadata).
+
+---
+
 ## Additional Resources
 
 For more examples and advanced use cases, please refer to the [Examples Code](https://github.com/blnkfinance/blnk-ts/tree/main/examples).

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -10,6 +10,7 @@ import {BalanceMonitor} from "./balanceMonitors";
 import {Identity} from "./identity";
 import {LedgerBalances} from "./ledgerBalances";
 import {Ledgers} from "./ledgers";
+import {Metadata} from "./metadata";
 import {Reconciliation} from "./reconciliation";
 import {Search} from "./search";
 import {System} from "./system";
@@ -204,6 +205,10 @@ export class Blnk {
 
   get System(): System {
     return this.getService<System>(`System`);
+  }
+
+  get Metadata(): Metadata {
+    return this.getService<Metadata>(`Metadata`);
   }
 
   get getApiKey() {

--- a/src/blnk/endpoints/metadata.ts
+++ b/src/blnk/endpoints/metadata.ts
@@ -1,0 +1,52 @@
+import {BlnkLogger} from "../../types/blnkClient";
+import {BlnkRequest, FormatResponseType} from "../../types/general";
+import {UpdateMetadataData, UpdateMetadataResp} from "../../types/metadata";
+import {HandleError} from "../utils/logger";
+import {ValidateUpdateMetadataData} from "../utils/validators/metadataValidators";
+
+/**
+ * Metadata operations for ledgers, transactions, balances, and identities.
+ */
+export class Metadata {
+  private request: BlnkRequest;
+  private logger: BlnkLogger;
+  private formatResponse: FormatResponseType;
+
+  constructor(
+    request: BlnkRequest,
+    logger: BlnkLogger,
+    formatResponse: FormatResponseType,
+  ) {
+    this.request = request;
+    this.logger = logger;
+    this.formatResponse = formatResponse;
+  }
+
+  /**
+   * Updates metadata for a ledger, transaction, balance, or identity.
+   *
+   * @see https://docs.blnkfinance.com/reference/update-metadata
+   */
+  async update(id: string, data: UpdateMetadataData) {
+    try {
+      const validatorResponse = ValidateUpdateMetadataData(id, data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<
+        UpdateMetadataData,
+        UpdateMetadataResp
+      >(`${id}/metadata`, data, `POST`);
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.update.name,
+      );
+    }
+  }
+}

--- a/src/blnk/utils/validators/metadataValidators.ts
+++ b/src/blnk/utils/validators/metadataValidators.ts
@@ -1,0 +1,22 @@
+import {UpdateMetadataData} from "../../../types/metadata";
+import {IsValidString} from "../stringUtils";
+import {isValidMetaData} from "./ledgerBalance";
+
+export function ValidateUpdateMetadataData(
+  id: string,
+  data: UpdateMetadataData,
+): string | null {
+  if (!IsValidString(id) || id === ``) {
+    return `id is required`;
+  }
+
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type UpdateMetadataData`;
+  }
+
+  if (data.meta_data === undefined || !isValidMetaData(data.meta_data)) {
+    return `meta_data must be a valid object`;
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {Blnk} from "./blnk/endpoints/baseBlnkClient";
 import {Identity} from "./blnk/endpoints/identity";
 import {LedgerBalances} from "./blnk/endpoints/ledgerBalances";
 import {Ledgers} from "./blnk/endpoints/ledgers";
+import {Metadata} from "./blnk/endpoints/metadata";
 import {Reconciliation} from "./blnk/endpoints/reconciliation";
 import {Search} from "./blnk/endpoints/search";
 import {System} from "./blnk/endpoints/system";
@@ -30,6 +31,7 @@ export function BlnkInit(apiKey: string, options: BlnkClientOptions) {
       Search,
       Identity,
       System,
+      Metadata,
     },
     FormatResponse,
     fetch,

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -1,0 +1,7 @@
+export interface UpdateMetadataData {
+  meta_data: Record<string, unknown>;
+}
+
+export interface UpdateMetadataResp {
+  meta_data: Record<string, unknown>;
+}

--- a/tests/unit/blnk/endpoints/metadata.test.ts
+++ b/tests/unit/blnk/endpoints/metadata.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Metadata} from "../../../../src/blnk/endpoints/metadata";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {
+  UpdateMetadataData,
+  UpdateMetadataResp,
+} from "../../../../src/types/metadata";
+
+const validData: UpdateMetadataData = {
+  meta_data: {
+    project_owner: `Acme LLC`,
+    update_status: `Approved`,
+  },
+};
+
+const mockResponse: UpdateMetadataResp = {
+  meta_data: {
+    project_owner: `Acme LLC`,
+    update_status: `Approved`,
+  },
+};
+
+tap.test(`Issue #27 — Metadata.update`, async t => {
+  t.test(`update POSTs {id}/metadata`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const metadata = new Metadata(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await metadata.update(`ldg_test_123`, validData);
+
+    tt.match(capturedRequest.args(), [
+      [`ldg_test_123/metadata`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.same(response.data?.meta_data, validData.meta_data);
+    tt.end();
+  });
+
+  t.test(`update rejects empty id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const metadata = new Metadata(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await metadata.update(``, validData);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `id is required`);
+    tt.end();
+  });
+
+  t.test(`update rejects invalid meta_data`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const metadata = new Metadata(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await metadata.update(`ldg_test_123`, {
+      meta_data: null as unknown as Record<string, unknown>,
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /meta_data/);
+    tt.end();
+  });
+
+  t.test(`update forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Entity not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const metadata = new Metadata(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await metadata.update(`ldg_missing`, validData);
+
+    tt.match(capturedRequest.args(), [
+      [`ldg_missing/metadata`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/metadataValidators.test.ts
+++ b/tests/unit/blnk/utils/metadataValidators.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateUpdateMetadataData} from "../../../../src/blnk/utils/validators/metadataValidators";
+import {UpdateMetadataData} from "../../../../src/types/metadata";
+
+const validData: UpdateMetadataData = {
+  meta_data: {project_owner: `Acme LLC`},
+};
+
+tap.test(`ValidateUpdateMetadataData`, async t => {
+  t.test(`accepts valid payload`, tt => {
+    tt.equal(ValidateUpdateMetadataData(`ldg_123`, validData), null);
+    tt.end();
+  });
+
+  t.test(`rejects empty id`, tt => {
+    tt.equal(ValidateUpdateMetadataData(``, validData), `id is required`);
+    tt.end();
+  });
+
+  t.test(`rejects missing meta_data`, tt => {
+    tt.match(
+      ValidateUpdateMetadataData(`ldg_123`, {} as UpdateMetadataData),
+      /meta_data/,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects non-object meta_data`, tt => {
+    tt.match(
+      ValidateUpdateMetadataData(`ldg_123`, {
+        meta_data: `invalid` as unknown as Record<string, unknown>,
+      }),
+      /meta_data/,
+    );
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds new `Metadata` service with `Metadata.update(id, data)` calling `POST /{id}/metadata`
- Registers `Metadata` on `BlnkInit` and `Blnk` client (`blnk.Metadata`)
- Introduces `UpdateMetadataData` and `UpdateMetadataResp` types (`meta_data` object)
- Client-side validation: non-empty id, required object `meta_data`
- Unit tests for endpoint and validator
- README endpoint map + usage example

## Acceptance criteria
- [x] Add `Metadata.update` calling `/{id}/metadata`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] Example in README
- [x] Register new `Metadata` service on `BlnkInit` / `index.ts`

## Test plan
- [x] `npm run test:unit` — 656 passing
- [x] `npm run lint` — 0 errors
- [ ] Postman **TS SDK (#27)** folder in *Blnk SDK Issues — Local Core Tests (fixed)* — self-setup creates ledger if needed, then POST metadata