### PR TITLE
Add Hooks.create (POST /hooks) (closes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,34 @@ See the [Update metadata reference](https://docs.blnkfinance.com/reference/updat
 
 ---
 
+## Hooks
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `Hooks.create(data)` | `POST /hooks` | Register a pre- or post-transaction webhook |
+
+> Hook management requires the **master key** (`server.secret_key`) in `X-Blnk-Key`. Regular API keys return `403`.
+
+### Register a hook
+
+```typescript
+const { Hooks } = blnk;
+
+const hook = await Hooks.create({
+  name: 'Pre-transaction validation',
+  url: 'https://api.example.com/validate',
+  type: 'PRE_TRANSACTION',
+  active: true,
+  timeout: 30,
+  retry_count: 3,
+});
+// hook.data?.id — registered hook ID
+```
+
+See the [Register hooks reference](https://docs.blnkfinance.com/reference/create-hooks).
+
+---
+
 ## Additional Resources
 
 For more examples and advanced use cases, please refer to the [Examples Code](https://github.com/blnkfinance/blnk-ts/tree/main/examples).

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -7,6 +7,7 @@ import {
 } from "../../types/general";
 import {HandleError} from "../utils/logger";
 import {BalanceMonitor} from "./balanceMonitors";
+import {Hooks} from "./hooks";
 import {Identity} from "./identity";
 import {LedgerBalances} from "./ledgerBalances";
 import {Ledgers} from "./ledgers";
@@ -209,6 +210,10 @@ export class Blnk {
 
   get Metadata(): Metadata {
     return this.getService<Metadata>(`Metadata`);
+  }
+
+  get Hooks(): Hooks {
+    return this.getService<Hooks>(`Hooks`);
   }
 
   get getApiKey() {

--- a/src/blnk/endpoints/hooks.ts
+++ b/src/blnk/endpoints/hooks.ts
@@ -1,0 +1,53 @@
+import {BlnkLogger} from "../../types/blnkClient";
+import {BlnkRequest, FormatResponseType} from "../../types/general";
+import {CreateHookData, HookResp} from "../../types/hooks";
+import {HandleError} from "../utils/logger";
+import {ValidateCreateHookData} from "../utils/validators/hookValidators";
+
+/**
+ * Webhook management operations (master key required on Core).
+ */
+export class Hooks {
+  private request: BlnkRequest;
+  private logger: BlnkLogger;
+  private formatResponse: FormatResponseType;
+
+  constructor(
+    request: BlnkRequest,
+    logger: BlnkLogger,
+    formatResponse: FormatResponseType,
+  ) {
+    this.request = request;
+    this.logger = logger;
+    this.formatResponse = formatResponse;
+  }
+
+  /**
+   * Registers a new webhook.
+   *
+   * @see https://docs.blnkfinance.com/reference/create-hooks
+   */
+  async create(data: CreateHookData) {
+    try {
+      const validatorResponse = ValidateCreateHookData(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<CreateHookData, HookResp>(
+        `hooks`,
+        data,
+        `POST`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.create.name,
+      );
+    }
+  }
+}

--- a/src/blnk/utils/validators/hookValidators.ts
+++ b/src/blnk/utils/validators/hookValidators.ts
@@ -1,0 +1,37 @@
+import {CreateHookData, HookType} from "../../../types/hooks";
+import {IsValidNumber, IsValidString} from "../stringUtils";
+
+const isValidHookType = (type: HookType) =>
+  [`PRE_TRANSACTION`, `POST_TRANSACTION`].includes(type);
+
+export function ValidateCreateHookData(data: CreateHookData): string | null {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type CreateHookData`;
+  }
+
+  if (!IsValidString(data.name) || data.name === ``) {
+    return `name is required`;
+  }
+
+  if (!IsValidString(data.url) || data.url === ``) {
+    return `url is required`;
+  }
+
+  if (!IsValidString(data.type) || !isValidHookType(data.type)) {
+    return `type must be PRE_TRANSACTION or POST_TRANSACTION`;
+  }
+
+  if (typeof data.active !== `boolean`) {
+    return `active must be a boolean`;
+  }
+
+  if (!IsValidNumber(data.timeout) || data.timeout <= 0) {
+    return `timeout must be a positive number`;
+  }
+
+  if (!IsValidNumber(data.retry_count) || data.retry_count < 0) {
+    return `retry_count must be a non-negative number`;
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {BalanceMonitor} from "./blnk/endpoints/balanceMonitors";
 import {Blnk} from "./blnk/endpoints/baseBlnkClient";
+import {Hooks} from "./blnk/endpoints/hooks";
 import {Identity} from "./blnk/endpoints/identity";
 import {LedgerBalances} from "./blnk/endpoints/ledgerBalances";
 import {Ledgers} from "./blnk/endpoints/ledgers";
@@ -32,6 +33,7 @@ export function BlnkInit(apiKey: string, options: BlnkClientOptions) {
       Identity,
       System,
       Metadata,
+      Hooks,
     },
     FormatResponse,
     fetch,

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,0 +1,23 @@
+export type HookType = `PRE_TRANSACTION` | `POST_TRANSACTION`;
+
+export interface CreateHookData {
+  name: string;
+  url: string;
+  type: HookType;
+  active: boolean;
+  timeout: number;
+  retry_count: number;
+}
+
+export interface HookResp {
+  id: string;
+  name: string;
+  url: string;
+  type: HookType;
+  active: boolean;
+  timeout: number;
+  retry_count: number;
+  created_at: string;
+  last_run: string;
+  last_success: boolean;
+}

--- a/tests/unit/blnk/endpoints/hooks.test.ts
+++ b/tests/unit/blnk/endpoints/hooks.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Hooks} from "../../../../src/blnk/endpoints/hooks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {CreateHookData, HookResp} from "../../../../src/types/hooks";
+
+const validData: CreateHookData = {
+  name: `Pre-transaction validation`,
+  url: `https://api.example.com/validate`,
+  type: `PRE_TRANSACTION`,
+  active: true,
+  timeout: 30,
+  retry_count: 3,
+};
+
+const mockResponse: HookResp = {
+  id: `hk_test_123`,
+  name: validData.name,
+  url: validData.url,
+  type: validData.type,
+  active: validData.active,
+  timeout: validData.timeout,
+  retry_count: validData.retry_count,
+  created_at: `2026-06-12T04:50:00.000Z`,
+  last_run: `0001-01-01T00:00:00Z`,
+  last_success: false,
+};
+
+tap.test(`Issue #28 — Hooks.create`, async t => {
+  t.test(`create POSTs hooks`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 201,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.create(validData);
+
+    tt.match(capturedRequest.args(), [[`hooks`, validData, `POST`]]);
+    tt.equal(response.status, 201);
+    tt.equal(response.data?.id, `hk_test_123`);
+    tt.equal(response.data?.type, `PRE_TRANSACTION`);
+    tt.end();
+  });
+
+  t.test(`create returns 400 for invalid payload`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 201,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.create({
+      ...validData,
+      type: `INVALID` as CreateHookData[`type`],
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /type/);
+    tt.end();
+  });
+
+  t.test(`create forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 403,
+      message: `hook management requires master key`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.create(validData);
+
+    tt.match(capturedRequest.args(), [[`hooks`, validData, `POST`]]);
+    tt.equal(response.status, 403);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/hookValidators.test.ts
+++ b/tests/unit/blnk/utils/hookValidators.test.ts
@@ -1,0 +1,65 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateCreateHookData} from "../../../../src/blnk/utils/validators/hookValidators";
+import {CreateHookData} from "../../../../src/types/hooks";
+
+const validData: CreateHookData = {
+  name: `Pre-transaction validation`,
+  url: `https://api.example.com/validate`,
+  type: `PRE_TRANSACTION`,
+  active: true,
+  timeout: 30,
+  retry_count: 3,
+};
+
+tap.test(`ValidateCreateHookData`, async t => {
+  t.test(`accepts valid payload`, tt => {
+    tt.equal(ValidateCreateHookData(validData), null);
+    tt.end();
+  });
+
+  t.test(`rejects empty name`, tt => {
+    tt.match(ValidateCreateHookData({...validData, name: ``}), /name/);
+    tt.end();
+  });
+
+  t.test(`rejects empty url`, tt => {
+    tt.match(ValidateCreateHookData({...validData, url: ``}), /url/);
+    tt.end();
+  });
+
+  t.test(`rejects invalid type`, tt => {
+    tt.match(
+      ValidateCreateHookData({
+        ...validData,
+        type: `INVALID` as CreateHookData[`type`],
+      }),
+      /type/,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects non-boolean active`, tt => {
+    tt.match(
+      ValidateCreateHookData({
+        ...validData,
+        active: `true` as unknown as boolean,
+      }),
+      /active/,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects non-positive timeout`, tt => {
+    tt.match(ValidateCreateHookData({...validData, timeout: 0}), /timeout/);
+    tt.end();
+  });
+
+  t.test(`rejects negative retry_count`, tt => {
+    tt.match(
+      ValidateCreateHookData({...validData, retry_count: -1}),
+      /retry_count/,
+    );
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds new `Hooks` service with `Hooks.create(data)` calling `POST /hooks`
- Registers `Hooks` on `BlnkInit` and `Blnk` client (`blnk.Hooks`)
- Introduces `CreateHookData`, `HookResp`, and `HookType` types aligned with Core
- Client-side validation for name, url, type, active, timeout, and retry_count
- Unit tests for endpoint and validator
- README endpoint map + usage example (notes master key requirement)

## Acceptance criteria
- [x] Add `Hooks.create` calling `/hooks`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] Example in README
- [x] Register new `Hooks` service on `BlnkInit` / `index.ts`

## Test plan
- [x] `npm run test:unit` — 673 passing
- [x] `npm run lint` — 0 errors
- [ ] Postman **TS SDK (#28)** folder — set collection `masterKey` to `server.secret_key`; expects `201` + hook `id`