### PR TITLE
Add Hooks.update (PUT /hooks/{id}) (closes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ See the [Update metadata reference](https://docs.blnkfinance.com/reference/updat
 | Method | Endpoint | Use case |
 |--------|----------|----------|
 | `Hooks.create(data)` | `POST /hooks` | Register a pre- or post-transaction webhook |
+| `Hooks.update(id, data)` | `PUT /hooks/{id}` | Update an existing webhook |
 
 > Hook management requires the **master key** (`server.secret_key`) in `X-Blnk-Key`. Regular API keys return `403`.
 
@@ -883,6 +884,21 @@ const hook = await Hooks.create({
 ```
 
 See the [Register hooks reference](https://docs.blnkfinance.com/reference/create-hooks).
+
+### Update a hook
+
+```typescript
+const updated = await Hooks.update(hook.data!.id, {
+  name: 'Pre-transaction validation (updated)',
+  url: 'https://api.example.com/validate-v2',
+  type: 'PRE_TRANSACTION',
+  active: false,
+  timeout: 45,
+  retry_count: 5,
+});
+```
+
+See the [Update hooks reference](https://docs.blnkfinance.com/reference/update-hooks).
 
 ---
 

--- a/src/blnk/endpoints/hooks.ts
+++ b/src/blnk/endpoints/hooks.ts
@@ -1,8 +1,11 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
-import {CreateHookData, HookResp} from "../../types/hooks";
+import {CreateHookData, HookResp, UpdateHookData} from "../../types/hooks";
 import {HandleError} from "../utils/logger";
-import {ValidateCreateHookData} from "../utils/validators/hookValidators";
+import {
+  ValidateCreateHookData,
+  ValidateUpdateHookData,
+} from "../utils/validators/hookValidators";
 
 /**
  * Webhook management operations (master key required on Core).
@@ -47,6 +50,39 @@ export class Hooks {
         this.logger,
         this.formatResponse,
         this.create.name,
+      );
+    }
+  }
+
+  /**
+   * Updates an existing webhook.
+   *
+   * @see https://docs.blnkfinance.com/reference/update-hooks
+   */
+  async update(id: string, data: UpdateHookData) {
+    try {
+      if (!id) {
+        return this.formatResponse(400, `hook id is required`, null);
+      }
+
+      const validatorResponse = ValidateUpdateHookData(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<UpdateHookData, HookResp>(
+        `hooks/${id}`,
+        data,
+        `PUT`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.update.name,
       );
     }
   }

--- a/src/blnk/utils/validators/hookValidators.ts
+++ b/src/blnk/utils/validators/hookValidators.ts
@@ -1,4 +1,4 @@
-import {CreateHookData, HookType} from "../../../types/hooks";
+import {CreateHookData, HookType, UpdateHookData} from "../../../types/hooks";
 import {IsValidNumber, IsValidString} from "../stringUtils";
 
 const isValidHookType = (type: HookType) =>
@@ -34,4 +34,8 @@ export function ValidateCreateHookData(data: CreateHookData): string | null {
   }
 
   return null;
+}
+
+export function ValidateUpdateHookData(data: UpdateHookData): string | null {
+  return ValidateCreateHookData(data);
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -9,6 +9,8 @@ export interface CreateHookData {
   retry_count: number;
 }
 
+export type UpdateHookData = CreateHookData;
+
 export interface HookResp {
   id: string;
   name: string;

--- a/tests/unit/blnk/endpoints/hooks.test.ts
+++ b/tests/unit/blnk/endpoints/hooks.test.ts
@@ -3,7 +3,11 @@ import tap from "tap";
 import {Hooks} from "../../../../src/blnk/endpoints/hooks";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import {createMockLogger} from "../../../mocks/blnkClientMocks";
-import {CreateHookData, HookResp} from "../../../../src/types/hooks";
+import {
+  CreateHookData,
+  HookResp,
+  UpdateHookData,
+} from "../../../../src/types/hooks";
 
 const validData: CreateHookData = {
   name: `Pre-transaction validation`,
@@ -82,6 +86,94 @@ tap.test(`Issue #28 — Hooks.create`, async t => {
 
     tt.match(capturedRequest.args(), [[`hooks`, validData, `POST`]]);
     tt.equal(response.status, 403);
+    tt.end();
+  });
+});
+
+tap.test(`Issue #29 — Hooks.update`, async t => {
+  const updateData: UpdateHookData = {
+    name: `Pre-transaction validation (updated)`,
+    url: `https://api.example.com/validate-v2`,
+    type: `PRE_TRANSACTION`,
+    active: false,
+    timeout: 45,
+    retry_count: 5,
+  };
+
+  t.test(`update PUTs hooks/{id}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: {...mockResponse, ...updateData} as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.update(`hk_test_123`, updateData);
+
+    tt.match(capturedRequest.args(), [
+      [`hooks/hk_test_123`, updateData, `PUT`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.active, false);
+    tt.equal(response.data?.timeout, 45);
+    tt.end();
+  });
+
+  t.test(`update returns 400 for empty id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.update(``, updateData);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /hook id/);
+    tt.end();
+  });
+
+  t.test(`update returns 400 for invalid payload`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.update(`hk_test_123`, {
+      ...updateData,
+      timeout: 0,
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /timeout/);
+    tt.end();
+  });
+
+  t.test(`update forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `hook not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.update(`hk_missing`, updateData);
+
+    tt.match(capturedRequest.args(), [[`hooks/hk_missing`, updateData, `PUT`]]);
+    tt.equal(response.status, 404);
     tt.end();
   });
 });

--- a/tests/unit/blnk/utils/hookValidators.test.ts
+++ b/tests/unit/blnk/utils/hookValidators.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
-import {ValidateCreateHookData} from "../../../../src/blnk/utils/validators/hookValidators";
+import {
+  ValidateCreateHookData,
+  ValidateUpdateHookData,
+} from "../../../../src/blnk/utils/validators/hookValidators";
 import {CreateHookData} from "../../../../src/types/hooks";
 
 const validData: CreateHookData = {
@@ -59,6 +62,24 @@ tap.test(`ValidateCreateHookData`, async t => {
     tt.match(
       ValidateCreateHookData({...validData, retry_count: -1}),
       /retry_count/,
+    );
+    tt.end();
+  });
+});
+
+tap.test(`ValidateUpdateHookData`, async t => {
+  t.test(`accepts valid payload`, tt => {
+    tt.equal(ValidateUpdateHookData(validData), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid type`, tt => {
+    tt.match(
+      ValidateUpdateHookData({
+        ...validData,
+        type: `INVALID` as CreateHookData[`type`],
+      }),
+      /type/,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Adds `Hooks.update(id, data)` calling `PUT /hooks/{id}`
- Introduces `UpdateHookData` type (same body shape as create) and `ValidateUpdateHookData`
- Unit tests for endpoint and validator
- README endpoint map + usage example (notes master key requirement)

## Acceptance criteria
- [x] Add `Hooks.update` calling `/hooks` (Core: `PUT /hooks/{id}`)
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation aligned with API rules
- [x] Unit test with mocked HTTP
- [x] Example in README

## Test plan
- [x] `npm run test:unit` — 688 passing
- [x] `npm run lint` — 0 errors
- [ ] Postman **TS SDK (#29)** folder — run both requests in order (setup create → update); expects `200` + updated fields