### PR TITLE
Add Hooks.get (GET /hooks/{id}) (closes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ See the [Update metadata reference](https://docs.blnkfinance.com/reference/updat
 | Method | Endpoint | Use case |
 |--------|----------|----------|
 | `Hooks.create(data)` | `POST /hooks` | Register a pre- or post-transaction webhook |
+| `Hooks.get(id)` | `GET /hooks/{id}` | View hook details |
 | `Hooks.update(id, data)` | `PUT /hooks/{id}` | Update an existing webhook |
 
 > Hook management requires the **master key** (`server.secret_key`) in `X-Blnk-Key`. Regular API keys return `403`.
@@ -884,6 +885,15 @@ const hook = await Hooks.create({
 ```
 
 See the [Register hooks reference](https://docs.blnkfinance.com/reference/create-hooks).
+
+### View a hook
+
+```typescript
+const hookDetails = await Hooks.get(hook.data!.id);
+// hookDetails.data?.name, hookDetails.data?.active, etc.
+```
+
+See the [View hooks reference](https://docs.blnkfinance.com/reference/view-hooks).
 
 ### Update a hook
 

--- a/src/blnk/endpoints/hooks.ts
+++ b/src/blnk/endpoints/hooks.ts
@@ -55,6 +55,34 @@ export class Hooks {
   }
 
   /**
+   * Retrieves a webhook by ID.
+   *
+   * @see https://docs.blnkfinance.com/reference/view-hooks
+   */
+  async get(id: string) {
+    try {
+      if (!id) {
+        return this.formatResponse(400, `hook id is required`, null);
+      }
+
+      const response = await this.request<undefined, HookResp>(
+        `hooks/${id}`,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.get.name,
+      );
+    }
+  }
+
+  /**
    * Updates an existing webhook.
    *
    * @see https://docs.blnkfinance.com/reference/update-hooks

--- a/tests/unit/blnk/endpoints/hooks.test.ts
+++ b/tests/unit/blnk/endpoints/hooks.test.ts
@@ -90,6 +90,62 @@ tap.test(`Issue #28 — Hooks.create`, async t => {
   });
 });
 
+tap.test(`Issue #30 — Hooks.get`, async t => {
+  t.test(`get GETs hooks/{id}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.get(`hk_test_123`);
+
+    tt.match(capturedRequest.args(), [[`hooks/hk_test_123`, undefined, `GET`]]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.id, `hk_test_123`);
+    tt.equal(response.data?.type, `PRE_TRANSACTION`);
+    tt.end();
+  });
+
+  t.test(`get returns 400 for empty id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.get(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /hook id/);
+    tt.end();
+  });
+
+  t.test(`get forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `hook not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.get(`hk_missing`);
+
+    tt.match(capturedRequest.args(), [[`hooks/hk_missing`, undefined, `GET`]]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});
+
 tap.test(`Issue #29 — Hooks.update`, async t => {
   const updateData: UpdateHookData = {
     name: `Pre-transaction validation (updated)`,


### PR DESCRIPTION
## Summary
- Adds `Hooks.get(id)` calling `GET /hooks/{id}`
- Reuses existing `HookResp` type for the response
- Unit tests for endpoint (happy path, empty id, API error forwarding)
- README endpoint map + usage example

## Acceptance criteria
- [x] Add `Hooks.get` calling `/hooks/{hook_id}`
- [x] Request/response TypeScript types match reference fields
- [x] Client-side validation (empty id guard)
- [x] Unit test with mocked HTTP
- [x] Example in README

## Test plan
- [x] `npm run test:unit` — 698 passing
- [x] `npm run lint` — 0 errors
- [ ] Postman **TS SDK (#30)** folder — run both requests in order (setup create → get); expects `200` + hook fields