### PR TITLE
Add Hooks.list (GET /hooks) (closes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ See the [Update metadata reference](https://docs.blnkfinance.com/reference/updat
 | Method | Endpoint | Use case |
 |--------|----------|----------|
 | `Hooks.create(data)` | `POST /hooks` | Register a pre- or post-transaction webhook |
+| `Hooks.list(options?)` | `GET /hooks` | List hooks, optionally by `type` query |
 | `Hooks.get(id)` | `GET /hooks/{id}` | View hook details |
 | `Hooks.update(id, data)` | `PUT /hooks/{id}` | Update an existing webhook |
 
@@ -885,6 +886,15 @@ const hook = await Hooks.create({
 ```
 
 See the [Register hooks reference](https://docs.blnkfinance.com/reference/create-hooks).
+
+### List hooks
+
+```typescript
+const allHooks = await Hooks.list();
+const preTxnHooks = await Hooks.list({ type: 'PRE_TRANSACTION' });
+```
+
+See the [List hooks by type reference](https://docs.blnkfinance.com/reference/list-hooks-by-type).
 
 ### View a hook
 

--- a/src/blnk/endpoints/hooks.ts
+++ b/src/blnk/endpoints/hooks.ts
@@ -1,9 +1,15 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
-import {CreateHookData, HookResp, UpdateHookData} from "../../types/hooks";
+import {
+  CreateHookData,
+  HookResp,
+  ListHooksOptions,
+  UpdateHookData,
+} from "../../types/hooks";
 import {HandleError} from "../utils/logger";
 import {
   ValidateCreateHookData,
+  ValidateListHooksOptions,
   ValidateUpdateHookData,
 } from "../utils/validators/hookValidators";
 
@@ -50,6 +56,38 @@ export class Hooks {
         this.logger,
         this.formatResponse,
         this.create.name,
+      );
+    }
+  }
+
+  /**
+   * Lists webhooks, optionally filtered by type.
+   *
+   * @see https://docs.blnkfinance.com/reference/list-hooks-by-type
+   */
+  async list(options?: ListHooksOptions) {
+    try {
+      const validatorResponse = ValidateListHooksOptions(options);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const endpoint =
+        options?.type !== undefined ? `hooks?type=${options.type}` : `hooks`;
+
+      const response = await this.request<undefined, HookResp[]>(
+        endpoint,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.list.name,
       );
     }
   }

--- a/src/blnk/utils/validators/hookValidators.ts
+++ b/src/blnk/utils/validators/hookValidators.ts
@@ -1,4 +1,9 @@
-import {CreateHookData, HookType, UpdateHookData} from "../../../types/hooks";
+import {
+  CreateHookData,
+  HookType,
+  ListHooksOptions,
+  UpdateHookData,
+} from "../../../types/hooks";
 import {IsValidNumber, IsValidString} from "../stringUtils";
 
 const isValidHookType = (type: HookType) =>
@@ -38,4 +43,25 @@ export function ValidateCreateHookData(data: CreateHookData): string | null {
 
 export function ValidateUpdateHookData(data: UpdateHookData): string | null {
   return ValidateCreateHookData(data);
+}
+
+export function ValidateListHooksOptions(
+  options?: ListHooksOptions,
+): string | null {
+  if (options === undefined) {
+    return null;
+  }
+
+  if (!options || typeof options !== `object`) {
+    return `options must be a valid object`;
+  }
+
+  if (
+    options.type !== undefined &&
+    (!IsValidString(options.type) || !isValidHookType(options.type))
+  ) {
+    return `type must be PRE_TRANSACTION or POST_TRANSACTION`;
+  }
+
+  return null;
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -11,6 +11,10 @@ export interface CreateHookData {
 
 export type UpdateHookData = CreateHookData;
 
+export interface ListHooksOptions {
+  type?: HookType;
+}
+
 export interface HookResp {
   id: string;
   name: string;

--- a/tests/unit/blnk/endpoints/hooks.test.ts
+++ b/tests/unit/blnk/endpoints/hooks.test.ts
@@ -90,6 +90,84 @@ tap.test(`Issue #28 — Hooks.create`, async t => {
   });
 });
 
+tap.test(`Issue #31 — Hooks.list`, async t => {
+  t.test(`list GETs hooks without type filter`, async tt => {
+    const mockLogger = createMockLogger();
+    const listResponse = [mockResponse];
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: listResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.list();
+
+    tt.match(capturedRequest.args(), [[`hooks`, undefined, `GET`]]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.length, 1);
+    tt.equal(response.data?.[0]?.id, `hk_test_123`);
+    tt.end();
+  });
+
+  t.test(`list GETs hooks?type= when type provided`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: [] as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.list({type: `POST_TRANSACTION`});
+
+    tt.match(capturedRequest.args(), [
+      [`hooks?type=POST_TRANSACTION`, undefined, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.end();
+  });
+
+  t.test(`list returns 400 for invalid type`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: [] as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.list({
+      type: `INVALID` as CreateHookData[`type`],
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /type/);
+    tt.end();
+  });
+
+  t.test(`list forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 403,
+      message: `hook management requires master key`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.list();
+
+    tt.match(capturedRequest.args(), [[`hooks`, undefined, `GET`]]);
+    tt.equal(response.status, 403);
+    tt.end();
+  });
+});
+
 tap.test(`Issue #30 — Hooks.get`, async t => {
   t.test(`get GETs hooks/{id}`, async tt => {
     const mockLogger = createMockLogger();

--- a/tests/unit/blnk/utils/hookValidators.test.ts
+++ b/tests/unit/blnk/utils/hookValidators.test.ts
@@ -2,6 +2,7 @@
 import tap from "tap";
 import {
   ValidateCreateHookData,
+  ValidateListHooksOptions,
   ValidateUpdateHookData,
 } from "../../../../src/blnk/utils/validators/hookValidators";
 import {CreateHookData} from "../../../../src/types/hooks";
@@ -62,6 +63,33 @@ tap.test(`ValidateCreateHookData`, async t => {
     tt.match(
       ValidateCreateHookData({...validData, retry_count: -1}),
       /retry_count/,
+    );
+    tt.end();
+  });
+});
+
+tap.test(`ValidateListHooksOptions`, async t => {
+  t.test(`accepts undefined options`, tt => {
+    tt.equal(ValidateListHooksOptions(undefined), null);
+    tt.end();
+  });
+
+  t.test(`accepts empty options`, tt => {
+    tt.equal(ValidateListHooksOptions({}), null);
+    tt.end();
+  });
+
+  t.test(`accepts valid type`, tt => {
+    tt.equal(ValidateListHooksOptions({type: `PRE_TRANSACTION`}), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid type`, tt => {
+    tt.match(
+      ValidateListHooksOptions({
+        type: `INVALID` as CreateHookData[`type`],
+      }),
+      /type/,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Adds `Hooks.list(options?)` calling `GET /hooks` with optional `type` query (`PRE_TRANSACTION` / `POST_TRANSACTION`)
- Introduces `ListHooksOptions` type and `ValidateListHooksOptions` client-side validation
- Unit tests for endpoint and validator; README endpoint map + list example

## Test plan
- [x] `npm run test:unit` — 714 passing
- [x] Lint clean on changed files
- [ ] Postman **TS SDK (#31)** folder (3 requests: POST setup → GET all → GET by type)