### PR TITLE
Add Hooks.delete (DELETE /hooks/{id}) (closes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ See the [Update metadata reference](https://docs.blnkfinance.com/reference/updat
 | `Hooks.list(options?)` | `GET /hooks` | List hooks, optionally by `type` query |
 | `Hooks.get(id)` | `GET /hooks/{id}` | View hook details |
 | `Hooks.update(id, data)` | `PUT /hooks/{id}` | Update an existing webhook |
+| `Hooks.delete(id)` | `DELETE /hooks/{id}` | Delete a webhook |
 
 > Hook management requires the **master key** (`server.secret_key`) in `X-Blnk-Key`. Regular API keys return `403`.
 
@@ -919,6 +920,15 @@ const updated = await Hooks.update(hook.data!.id, {
 ```
 
 See the [Update hooks reference](https://docs.blnkfinance.com/reference/update-hooks).
+
+### Delete a hook
+
+```typescript
+const deleted = await Hooks.delete(hook.data!.id);
+// deleted.data?.message — "hook deleted successfully"
+```
+
+See the [Delete hooks reference](https://docs.blnkfinance.com/reference/delete-hooks).
 
 ---
 

--- a/src/blnk/endpoints/hooks.ts
+++ b/src/blnk/endpoints/hooks.ts
@@ -2,6 +2,7 @@ import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
   CreateHookData,
+  DeleteHookResp,
   HookResp,
   ListHooksOptions,
   UpdateHookData,
@@ -149,6 +150,34 @@ export class Hooks {
         this.logger,
         this.formatResponse,
         this.update.name,
+      );
+    }
+  }
+
+  /**
+   * Deletes a webhook by ID.
+   *
+   * @see https://docs.blnkfinance.com/reference/delete-hooks
+   */
+  async delete(id: string) {
+    try {
+      if (!id) {
+        return this.formatResponse(400, `hook id is required`, null);
+      }
+
+      const response = await this.request<undefined, DeleteHookResp>(
+        `hooks/${id}`,
+        undefined,
+        `DELETE`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.delete.name,
       );
     }
   }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -27,3 +27,7 @@ export interface HookResp {
   last_run: string;
   last_success: boolean;
 }
+
+export interface DeleteHookResp {
+  message: string;
+}

--- a/tests/unit/blnk/endpoints/hooks.test.ts
+++ b/tests/unit/blnk/endpoints/hooks.test.ts
@@ -5,6 +5,7 @@ import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import {createMockLogger} from "../../../mocks/blnkClientMocks";
 import {
   CreateHookData,
+  DeleteHookResp,
   HookResp,
   UpdateHookData,
 } from "../../../../src/types/hooks";
@@ -307,6 +308,69 @@ tap.test(`Issue #29 — Hooks.update`, async t => {
     const response = await hooks.update(`hk_missing`, updateData);
 
     tt.match(capturedRequest.args(), [[`hooks/hk_missing`, updateData, `PUT`]]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});
+
+tap.test(`Issue #32 — Hooks.delete`, async t => {
+  const deleteResponse: DeleteHookResp = {
+    message: `hook deleted successfully`,
+  };
+
+  t.test(`delete DELETEs hooks/{id}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: deleteResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.delete(`hk_test_123`);
+
+    tt.match(capturedRequest.args(), [
+      [`hooks/hk_test_123`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.message, `hook deleted successfully`);
+    tt.end();
+  });
+
+  t.test(`delete returns 400 for empty id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: deleteResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.delete(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /hook id/);
+    tt.end();
+  });
+
+  t.test(`delete forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `hook not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const hooks = new Hooks(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await hooks.delete(`hk_missing`);
+
+    tt.match(capturedRequest.args(), [
+      [`hooks/hk_missing`, undefined, `DELETE`],
+    ]);
     tt.equal(response.status, 404);
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Adds `Hooks.delete(id)` calling `DELETE /hooks/{id}`
- Introduces `DeleteHookResp` type for the `{ message }` response body
- Unit tests for endpoint (happy path, empty id, API error forwarding)
- README endpoint map + delete example

## Test plan
- [x] `npm run test:unit` — 723 passing
- [x] Lint clean on changed files
- [ ] Postman **TS SDK (#32)** folder (2 requests: POST setup → DELETE)