### PR TITLE
Add Identity.tokenize (POST /identities/{id}/tokenize) (closes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,14 @@ console.log('Identity Created:', newIdentity);
 ```typescript
 const { Identity } = blnk;
 
+// Use PascalCase struct field names — not the snake_case JSON keys on IdentityData.
 const tokenized = await Identity.tokenize(identity.data!.identity_id, {
-  fields: ['firstName', 'lastName', 'emailAddress', 'phoneNumber'],
+  fields: ['FirstName', 'LastName', 'EmailAddress', 'PhoneNumber'],
 });
 // tokenized.data?.message — "Fields tokenized successfully"
 ```
+
+> `fields` must be Core struct names (`FirstName`, `EmailAddress`, …). Passing `first_name` or `email_address` from `IdentityData` will be rejected.
 
 See the [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ const newIdentity = await Identity.create({
 console.log('Identity Created:', newIdentity);
 ```
 
+### Tokenize identity fields
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `Identity.tokenize(id, data)` | `POST /identities/{identity_id}/tokenize` | Tokenize multiple PII fields on an identity |
+
+```typescript
+const { Identity } = blnk;
+
+const tokenized = await Identity.tokenize(identity.data!.identity_id, {
+  fields: ['firstName', 'lastName', 'emailAddress', 'phoneNumber'],
+});
+// tokenized.data?.message — "Fields tokenized successfully"
+```
+
+See the [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
+
 ---
 
 ## 6. Creating Balances

--- a/src/blnk/endpoints/identity.ts
+++ b/src/blnk/endpoints/identity.ts
@@ -1,9 +1,17 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
-import {IdentityData, IdentityDataResponse} from "../../types/identity";
+import {
+  IdentityData,
+  IdentityDataResponse,
+  TokenizeIdentityData,
+  TokenizeIdentityResp,
+} from "../../types/identity";
 import {HandleError} from "../utils/logger";
 import {serializeIdentityData} from "../utils/identitySerialization";
-import {ValidateIdentity} from "../utils/validators/identityValidators";
+import {
+  ValidateIdentity,
+  ValidateTokenizeIdentityData,
+} from "../utils/validators/identityValidators";
 
 /**
  * Represents an Identity class that handles operations related to identity data.
@@ -179,6 +187,34 @@ export class Identity {
         this.logger,
         this.formatResponse,
         this.update.name,
+      );
+    }
+  }
+
+  /**
+   * Tokenizes multiple PII fields on an identity.
+   *
+   * @see https://docs.blnkfinance.com/reference/tokenize-identity
+   */
+  async tokenize(id: string, data: TokenizeIdentityData) {
+    try {
+      const validatorResponse = ValidateTokenizeIdentityData(id, data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<
+        TokenizeIdentityData,
+        TokenizeIdentityResp
+      >(`identities/${id}/tokenize`, data, `POST`);
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.tokenize.name,
       );
     }
   }

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -1,6 +1,7 @@
-import {IdentityData} from "../../../types/identity";
+import {IdentityData, TokenizeIdentityData} from "../../../types/identity";
 import {isValidMetaData} from "./ledgerBalance";
 import {isValidIdentityDateInput} from "../identitySerialization";
+import {IsValidArray, IsValidString} from "../stringUtils";
 
 const IDENTITY_ID_PATTERN =
   /^idt_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -34,6 +35,31 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
 
   if (data.meta_data !== undefined && !isValidMetaData(data.meta_data)) {
     return `meta_data must be a valid object if provided`;
+  }
+
+  return null;
+}
+
+export function ValidateTokenizeIdentityData(
+  id: string,
+  data: TokenizeIdentityData,
+): string | null {
+  if (!IsValidString(id) || id === ``) {
+    return `identity id is required`;
+  }
+
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type TokenizeIdentityData`;
+  }
+
+  if (!IsValidArray(data.fields) || data.fields.length === 0) {
+    return `at least one field must be specified`;
+  }
+
+  for (const field of data.fields) {
+    if (!IsValidString(field) || field === ``) {
+      return `each field must be a non-empty string`;
+    }
   }
 
   return null;

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -34,9 +34,23 @@ export interface IdentityDataResponse<
   dob?: string;
 }
 
+/** Core tokenization field names (Go struct fields), not `IdentityData` JSON keys. */
+export type TokenizableIdentityField =
+  | `FirstName`
+  | `LastName`
+  | `OtherNames`
+  | `EmailAddress`
+  | `PhoneNumber`
+  | `Street`
+  | `PostCode`;
+
 export interface TokenizeIdentityData {
-  /** Identity field names to tokenize (e.g. `firstName`, `emailAddress`). */
-  fields: string[];
+  /**
+   * Field names to tokenize. Use PascalCase struct names (`FirstName`,
+   * `EmailAddress`), not the snake_case keys on `IdentityData` (`first_name`,
+   * `email_address`) — Core rejects snake_case with "field is not tokenizable".
+   */
+  fields: TokenizableIdentityField[];
 }
 
 export interface TokenizeIdentityResp {

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -33,3 +33,12 @@ export interface IdentityDataResponse<
   /** Date of birth as returned by the API (ISO 8601 string). */
   dob?: string;
 }
+
+export interface TokenizeIdentityData {
+  /** Identity field names to tokenize (e.g. `firstName`, `emailAddress`). */
+  fields: string[];
+}
+
+export interface TokenizeIdentityResp {
+  message: string;
+}

--- a/tests/unit/blnk/endpoints/identityTokenize.test.ts
+++ b/tests/unit/blnk/endpoints/identityTokenize.test.ts
@@ -1,0 +1,94 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Identity} from "../../../../src/blnk/endpoints/identity";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {
+  TokenizeIdentityData,
+  TokenizeIdentityResp,
+} from "../../../../src/types/identity";
+
+const validData: TokenizeIdentityData = {
+  fields: [`firstName`, `emailAddress`],
+};
+
+const mockResponse: TokenizeIdentityResp = {
+  message: `Fields tokenized successfully`,
+};
+
+tap.test(`Issue #23 — Identity.tokenize`, async t => {
+  t.test(`tokenize POSTs identities/{id}/tokenize`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenize(`idt_test_123`, validData);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenize`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.message, `Fields tokenized successfully`);
+    tt.end();
+  });
+
+  t.test(`tokenize rejects empty identity id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenize(``, validData);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `identity id is required`);
+    tt.end();
+  });
+
+  t.test(`tokenize rejects empty fields`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenize(`idt_test_123`, {fields: []});
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `at least one field must be specified`);
+    tt.end();
+  });
+
+  t.test(`tokenize forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Identity not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenize(`idt_missing`, validData);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_missing/tokenize`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/endpoints/identityTokenize.test.ts
+++ b/tests/unit/blnk/endpoints/identityTokenize.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../src/types/identity";
 
 const validData: TokenizeIdentityData = {
-  fields: [`firstName`, `emailAddress`],
+  fields: [`FirstName`, `EmailAddress`],
 };
 
 const mockResponse: TokenizeIdentityResp = {
@@ -17,6 +17,28 @@ const mockResponse: TokenizeIdentityResp = {
 };
 
 tap.test(`Issue #23 — Identity.tokenize`, async t => {
+  t.test(`tokenize uses PascalCase struct field names`, async tt => {
+    const mockLogger = createMockLogger();
+    const pascalCaseData: TokenizeIdentityData = {
+      fields: [`FirstName`, `LastName`, `EmailAddress`, `PhoneNumber`],
+    };
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenize(`idt_test_123`, pascalCaseData);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenize`, pascalCaseData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.end();
+  });
+
   t.test(`tokenize POSTs identities/{id}/tokenize`, async tt => {
     const mockLogger = createMockLogger();
     const thirdPartyRequest = async <R>() => ({

--- a/tests/unit/blnk/utils/identityTokenizeValidators.test.ts
+++ b/tests/unit/blnk/utils/identityTokenizeValidators.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateTokenizeIdentityData} from "../../../../src/blnk/utils/validators/identityValidators";
+import {TokenizeIdentityData} from "../../../../src/types/identity";
+
+tap.test(`ValidateTokenizeIdentityData`, async t => {
+  const validData: TokenizeIdentityData = {
+    fields: [`firstName`, `emailAddress`],
+  };
+
+  t.equal(ValidateTokenizeIdentityData(`idt_test_123`, validData), null);
+  t.equal(
+    ValidateTokenizeIdentityData(``, validData),
+    `identity id is required`,
+  );
+  t.equal(
+    ValidateTokenizeIdentityData(`idt_test_123`, {fields: []}),
+    `at least one field must be specified`,
+  );
+  t.equal(
+    ValidateTokenizeIdentityData(`idt_test_123`, {
+      fields: [`firstName`, ``],
+    }),
+    `each field must be a non-empty string`,
+  );
+  t.end();
+});

--- a/tests/unit/blnk/utils/identityTokenizeValidators.test.ts
+++ b/tests/unit/blnk/utils/identityTokenizeValidators.test.ts
@@ -5,7 +5,7 @@ import {TokenizeIdentityData} from "../../../../src/types/identity";
 
 tap.test(`ValidateTokenizeIdentityData`, async t => {
   const validData: TokenizeIdentityData = {
-    fields: [`firstName`, `emailAddress`],
+    fields: [`FirstName`, `EmailAddress`],
   };
 
   t.equal(ValidateTokenizeIdentityData(`idt_test_123`, validData), null);
@@ -19,7 +19,7 @@ tap.test(`ValidateTokenizeIdentityData`, async t => {
   );
   t.equal(
     ValidateTokenizeIdentityData(`idt_test_123`, {
-      fields: [`firstName`, ``],
+      fields: [`FirstName`, ``],
     }),
     `each field must be a non-empty string`,
   );


### PR DESCRIPTION
## Summary
- Add `Identity.tokenize(id, data)` calling `POST /identities/{identity_id}/tokenize`
- Add `TokenizeIdentityData` / `TokenizeIdentityResp` types and client-side validation (non-empty identity id, at least one field)
- Unit tests with mocked HTTP and README endpoint map entry
- Postman folder **TS SDK (#23)** added to collection `2a0ebd09-8869-45e8-84db-cee4da37a432`

## Test plan
- [x] `npm run test:unit` — 730 tests pass (including new identity tokenize tests)
- [x] ESLint on changed files — clean
- [ ] Run Postman folder **TS SDK (#23)** against local Core (`baseUrl=http://localhost:5001`)

Closes #23