### PR TITLE
Add ApiKeys.create (POST /api-keys) (closes #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,32 @@ See the [Delete hooks reference](https://docs.blnkfinance.com/reference/delete-h
 
 ---
 
+## API Keys
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `ApiKeys.create(data)` | `POST /api-keys` | Create a scoped API key |
+
+> Requires the **master key** or an API key with `api-keys:write` scope. The raw `key` value is only returned once at creation.
+
+### Create an API key
+
+```typescript
+const { ApiKeys } = blnk;
+
+const apiKey = await ApiKeys.create({
+  name: 'Service Account',
+  owner: 'merchant_a',
+  scopes: ['ledgers:read', 'balances:write'],
+  expires_at: '2026-03-11T00:00:00Z',
+});
+// apiKey.data?.key — store securely; shown only once
+```
+
+See the [Create API key reference](https://docs.blnkfinance.com/reference/create-api-key).
+
+---
+
 ## Additional Resources
 
 For more examples and advanced use cases, please refer to the [Examples Code](https://github.com/blnkfinance/blnk-ts/tree/main/examples).

--- a/src/blnk/endpoints/apiKeys.ts
+++ b/src/blnk/endpoints/apiKeys.ts
@@ -1,0 +1,53 @@
+import {BlnkLogger} from "../../types/blnkClient";
+import {ApiKeyResp, CreateApiKeyData} from "../../types/apiKeys";
+import {BlnkRequest, FormatResponseType} from "../../types/general";
+import {HandleError} from "../utils/logger";
+import {ValidateCreateApiKeyData} from "../utils/validators/apiKeyValidators";
+
+/**
+ * API key management operations (master key or `api-keys:write` scope required).
+ */
+export class ApiKeys {
+  private request: BlnkRequest;
+  private logger: BlnkLogger;
+  private formatResponse: FormatResponseType;
+
+  constructor(
+    request: BlnkRequest,
+    logger: BlnkLogger,
+    formatResponse: FormatResponseType,
+  ) {
+    this.request = request;
+    this.logger = logger;
+    this.formatResponse = formatResponse;
+  }
+
+  /**
+   * Creates a new API key with scoped permissions.
+   *
+   * @see https://docs.blnkfinance.com/reference/create-api-key
+   */
+  async create(data: CreateApiKeyData) {
+    try {
+      const validatorResponse = ValidateCreateApiKeyData(data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<CreateApiKeyData, ApiKeyResp>(
+        `api-keys`,
+        data,
+        `POST`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.create.name,
+      );
+    }
+  }
+}

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -6,6 +6,7 @@ import {
   ServicesMap,
 } from "../../types/general";
 import {HandleError} from "../utils/logger";
+import {ApiKeys} from "./apiKeys";
 import {BalanceMonitor} from "./balanceMonitors";
 import {Hooks} from "./hooks";
 import {Identity} from "./identity";
@@ -214,6 +215,10 @@ export class Blnk {
 
   get Hooks(): Hooks {
     return this.getService<Hooks>(`Hooks`);
+  }
+
+  get ApiKeys(): ApiKeys {
+    return this.getService<ApiKeys>(`ApiKeys`);
   }
 
   get getApiKey() {

--- a/src/blnk/utils/validators/apiKeyValidators.ts
+++ b/src/blnk/utils/validators/apiKeyValidators.ts
@@ -1,0 +1,38 @@
+import {CreateApiKeyData} from "../../../types/apiKeys";
+import {IsValidArray, IsValidString} from "../stringUtils";
+import {isValidTransactionDateInput} from "../transactionSerialization";
+
+export function ValidateCreateApiKeyData(
+  data: CreateApiKeyData,
+): string | null {
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type CreateApiKeyData`;
+  }
+
+  if (!IsValidString(data.name) || data.name === ``) {
+    return `name is required`;
+  }
+
+  if (!IsValidString(data.owner) || data.owner === ``) {
+    return `owner is required`;
+  }
+
+  if (!IsValidArray(data.scopes) || data.scopes.length === 0) {
+    return `at least one scope must be specified`;
+  }
+
+  for (const scope of data.scopes) {
+    if (!IsValidString(scope) || scope === ``) {
+      return `each scope must be a non-empty string`;
+    }
+  }
+
+  if (
+    !IsValidString(data.expires_at) ||
+    !isValidTransactionDateInput(data.expires_at)
+  ) {
+    return `expires_at must be a valid ISO 8601 datetime string`;
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import {ApiKeys} from "./blnk/endpoints/apiKeys";
 import {BalanceMonitor} from "./blnk/endpoints/balanceMonitors";
 import {Blnk} from "./blnk/endpoints/baseBlnkClient";
 import {Hooks} from "./blnk/endpoints/hooks";
@@ -34,6 +35,7 @@ export function BlnkInit(apiKey: string, options: BlnkClientOptions) {
       System,
       Metadata,
       Hooks,
+      ApiKeys,
     },
     FormatResponse,
     fetch,

--- a/src/types/apiKeys.ts
+++ b/src/types/apiKeys.ts
@@ -1,0 +1,20 @@
+export interface CreateApiKeyData {
+  name: string;
+  owner: string;
+  scopes: string[];
+  /** ISO 8601 expiration timestamp (e.g. `2026-03-11T00:00:00Z`). */
+  expires_at: string;
+}
+
+export interface ApiKeyResp {
+  api_key_id: string;
+  key: string;
+  name: string;
+  owner_id: string;
+  scopes: string[];
+  expires_at: string;
+  created_at: string;
+  last_used_at: string;
+  is_revoked: boolean;
+  revoked_at?: string;
+}

--- a/tests/unit/blnk/endpoints/apiKeys.test.ts
+++ b/tests/unit/blnk/endpoints/apiKeys.test.ts
@@ -1,0 +1,85 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ApiKeys} from "../../../../src/blnk/endpoints/apiKeys";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {ApiKeyResp, CreateApiKeyData} from "../../../../src/types/apiKeys";
+
+const validData: CreateApiKeyData = {
+  name: `Service Account`,
+  owner: `merchant_a`,
+  scopes: [`ledgers:read`, `balances:write`],
+  expires_at: `2026-03-11T00:00:00Z`,
+};
+
+const mockResponse: ApiKeyResp = {
+  api_key_id: `api_key_test_123`,
+  key: `YVLIhuIplUzLRCcT9r7DQ_jsGKCXAn39JQ3n_o-Ll2Q=`,
+  name: validData.name,
+  owner_id: validData.owner,
+  scopes: validData.scopes,
+  expires_at: validData.expires_at,
+  created_at: `2026-06-12T05:50:00.000Z`,
+  last_used_at: `0001-01-01T00:00:00Z`,
+  is_revoked: false,
+};
+
+tap.test(`Issue #36 — ApiKeys.create`, async t => {
+  t.test(`create POSTs api-keys`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 201,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.create(validData);
+
+    tt.match(capturedRequest.args(), [[`api-keys`, validData, `POST`]]);
+    tt.equal(response.status, 201);
+    tt.equal(response.data?.api_key_id, `api_key_test_123`);
+    tt.equal(response.data?.key, mockResponse.key);
+    tt.equal(response.data?.owner_id, `merchant_a`);
+    tt.end();
+  });
+
+  t.test(`create returns 400 for invalid payload`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 201,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.create({
+      ...validData,
+      scopes: [],
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /scope/);
+    tt.end();
+  });
+
+  t.test(`create forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 403,
+      message: `forbidden`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.create(validData);
+
+    tt.match(capturedRequest.args(), [[`api-keys`, validData, `POST`]]);
+    tt.equal(response.status, 403);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/apiKeyValidators.test.ts
+++ b/tests/unit/blnk/utils/apiKeyValidators.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateCreateApiKeyData} from "../../../../src/blnk/utils/validators/apiKeyValidators";
+import {CreateApiKeyData} from "../../../../src/types/apiKeys";
+
+tap.test(`ValidateCreateApiKeyData`, async t => {
+  const validData: CreateApiKeyData = {
+    name: `Service Account`,
+    owner: `merchant_a`,
+    scopes: [`ledgers:read`],
+    expires_at: `2026-03-11T00:00:00Z`,
+  };
+
+  t.equal(ValidateCreateApiKeyData(validData), null);
+  t.equal(
+    ValidateCreateApiKeyData({...validData, name: ``}),
+    `name is required`,
+  );
+  t.equal(
+    ValidateCreateApiKeyData({...validData, owner: ``}),
+    `owner is required`,
+  );
+  t.equal(
+    ValidateCreateApiKeyData({...validData, scopes: []}),
+    `at least one scope must be specified`,
+  );
+  t.match(
+    ValidateCreateApiKeyData({...validData, scopes: [`ledgers:read`, ``]}),
+    /scope/,
+  );
+  t.match(
+    ValidateCreateApiKeyData({...validData, expires_at: `not-a-date`}),
+    /expires_at/,
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Adds new `ApiKeys` service with `ApiKeys.create(data)` calling `POST /api-keys`
- Registers `ApiKeys` on `BlnkInit` / `blnk.ApiKeys`
- Introduces `CreateApiKeyData` and `ApiKeyResp` types with client-side validation
- Unit tests for endpoint and validator; README endpoint map + create example

## Test plan
- [x] `npm run test:unit` — 758 passing
- [x] Lint clean on changed files
- [x] Live Core: `POST /api-keys` → 201 with `api_key_id` + `key`
- [ ] Postman **TS SDK (#36)** folder (1 request: POST create API key)