### PR TITLE
Add ApiKeys.list (GET /api-keys) (closes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,8 +957,9 @@ See the [Delete hooks reference](https://docs.blnkfinance.com/reference/delete-h
 | Method | Endpoint | Use case |
 |--------|----------|----------|
 | `ApiKeys.create(data)` | `POST /api-keys` | Create a scoped API key |
+| `ApiKeys.list(options?)` | `GET /api-keys` | List API keys for an owner |
 
-> Requires the **master key** or an API key with `api-keys:write` scope. The raw `key` value is only returned once at creation.
+> API key management requires the **master key** or scoped permissions (`api-keys:write` to create, `api-keys:read` to list). The raw `key` value is only returned once at creation.
 
 ### Create an API key
 
@@ -975,6 +976,15 @@ const apiKey = await ApiKeys.create({
 ```
 
 See the [Create API key reference](https://docs.blnkfinance.com/reference/create-api-key).
+
+### List API keys
+
+```typescript
+const keys = await ApiKeys.list({ owner: 'merchant_a' });
+// keys.data?.[0]?.api_key_id, keys.data?.[0]?.scopes, etc.
+```
+
+See the [List API keys reference](https://docs.blnkfinance.com/reference/get-api-key).
 
 ---
 

--- a/src/blnk/endpoints/apiKeys.ts
+++ b/src/blnk/endpoints/apiKeys.ts
@@ -1,8 +1,16 @@
 import {BlnkLogger} from "../../types/blnkClient";
-import {ApiKeyResp, CreateApiKeyData} from "../../types/apiKeys";
+import {
+  ApiKeyListItem,
+  ApiKeyResp,
+  CreateApiKeyData,
+  ListApiKeysOptions,
+} from "../../types/apiKeys";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {HandleError} from "../utils/logger";
-import {ValidateCreateApiKeyData} from "../utils/validators/apiKeyValidators";
+import {
+  ValidateCreateApiKeyData,
+  ValidateListApiKeysOptions,
+} from "../utils/validators/apiKeyValidators";
 
 /**
  * API key management operations (master key or `api-keys:write` scope required).
@@ -47,6 +55,40 @@ export class ApiKeys {
         this.logger,
         this.formatResponse,
         this.create.name,
+      );
+    }
+  }
+
+  /**
+   * Lists API keys for an owner.
+   *
+   * @see https://docs.blnkfinance.com/reference/get-api-key
+   */
+  async list(options?: ListApiKeysOptions) {
+    try {
+      const validatorResponse = ValidateListApiKeysOptions(options);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const endpoint =
+        options?.owner !== undefined
+          ? `api-keys?owner=${options.owner}`
+          : `api-keys`;
+
+      const response = await this.request<undefined, ApiKeyListItem[]>(
+        endpoint,
+        undefined,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.list.name,
       );
     }
   }

--- a/src/blnk/endpoints/apiKeys.ts
+++ b/src/blnk/endpoints/apiKeys.ts
@@ -1,6 +1,5 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {
-  ApiKeyListItem,
   ApiKeyResp,
   CreateApiKeyData,
   ListApiKeysOptions,
@@ -73,10 +72,10 @@ export class ApiKeys {
 
       const endpoint =
         options?.owner !== undefined
-          ? `api-keys?owner=${options.owner}`
+          ? `api-keys?owner=${encodeURIComponent(options.owner)}`
           : `api-keys`;
 
-      const response = await this.request<undefined, ApiKeyListItem[]>(
+      const response = await this.request<undefined, ApiKeyResp[]>(
         endpoint,
         undefined,
         `GET`,

--- a/src/blnk/utils/validators/apiKeyValidators.ts
+++ b/src/blnk/utils/validators/apiKeyValidators.ts
@@ -1,4 +1,4 @@
-import {CreateApiKeyData} from "../../../types/apiKeys";
+import {CreateApiKeyData, ListApiKeysOptions} from "../../../types/apiKeys";
 import {IsValidArray, IsValidString} from "../stringUtils";
 import {isValidTransactionDateInput} from "../transactionSerialization";
 
@@ -32,6 +32,27 @@ export function ValidateCreateApiKeyData(
     !isValidTransactionDateInput(data.expires_at)
   ) {
     return `expires_at must be a valid ISO 8601 datetime string`;
+  }
+
+  return null;
+}
+
+export function ValidateListApiKeysOptions(
+  options?: ListApiKeysOptions,
+): string | null {
+  if (options === undefined) {
+    return null;
+  }
+
+  if (!options || typeof options !== `object`) {
+    return `options must be a valid object`;
+  }
+
+  if (
+    options.owner !== undefined &&
+    (!IsValidString(options.owner) || options.owner === ``)
+  ) {
+    return `owner must be a non-empty string`;
   }
 
   return null;

--- a/src/types/apiKeys.ts
+++ b/src/types/apiKeys.ts
@@ -6,6 +6,10 @@ export interface CreateApiKeyData {
   expires_at: string;
 }
 
+export interface ListApiKeysOptions {
+  owner?: string;
+}
+
 export interface ApiKeyResp {
   api_key_id: string;
   key: string;
@@ -18,3 +22,6 @@ export interface ApiKeyResp {
   is_revoked: boolean;
   revoked_at?: string;
 }
+
+/** Listed API key (raw `key` value is not returned by Core). */
+export type ApiKeyListItem = Omit<ApiKeyResp, `key`> & {key?: string};

--- a/src/types/apiKeys.ts
+++ b/src/types/apiKeys.ts
@@ -22,6 +22,3 @@ export interface ApiKeyResp {
   is_revoked: boolean;
   revoked_at?: string;
 }
-
-/** Listed API key (raw `key` value is not returned by Core). */
-export type ApiKeyListItem = Omit<ApiKeyResp, `key`> & {key?: string};

--- a/tests/unit/blnk/endpoints/apiKeys.test.ts
+++ b/tests/unit/blnk/endpoints/apiKeys.test.ts
@@ -3,11 +3,7 @@ import tap from "tap";
 import {ApiKeys} from "../../../../src/blnk/endpoints/apiKeys";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import {createMockLogger} from "../../../mocks/blnkClientMocks";
-import {
-  ApiKeyListItem,
-  ApiKeyResp,
-  CreateApiKeyData,
-} from "../../../../src/types/apiKeys";
+import {ApiKeyResp, CreateApiKeyData} from "../../../../src/types/apiKeys";
 
 const validData: CreateApiKeyData = {
   name: `Service Account`,
@@ -89,8 +85,9 @@ tap.test(`Issue #36 — ApiKeys.create`, async t => {
 });
 
 tap.test(`Issue #37 — ApiKeys.list`, async t => {
-  const listItem: ApiKeyListItem = {
+  const listItem: ApiKeyResp = {
     api_key_id: `api_key_test_123`,
+    key: `$2a$10$hashedkeyvalue`,
     name: `Service Account`,
     owner_id: `merchant_a`,
     scopes: [`ledgers:read`],
@@ -133,6 +130,29 @@ tap.test(`Issue #37 — ApiKeys.list`, async t => {
 
     tt.match(capturedRequest.args(), [
       [`api-keys?owner=merchant_a`, undefined, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.end();
+  });
+
+  t.test(`list URL-encodes owner query param`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: [] as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.list({owner: `merchant a&role=admin`});
+
+    tt.match(capturedRequest.args(), [
+      [
+        `api-keys?owner=${encodeURIComponent(`merchant a&role=admin`)}`,
+        undefined,
+        `GET`,
+      ],
     ]);
     tt.equal(response.status, 200);
     tt.end();

--- a/tests/unit/blnk/endpoints/apiKeys.test.ts
+++ b/tests/unit/blnk/endpoints/apiKeys.test.ts
@@ -3,7 +3,11 @@ import tap from "tap";
 import {ApiKeys} from "../../../../src/blnk/endpoints/apiKeys";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import {createMockLogger} from "../../../mocks/blnkClientMocks";
-import {ApiKeyResp, CreateApiKeyData} from "../../../../src/types/apiKeys";
+import {
+  ApiKeyListItem,
+  ApiKeyResp,
+  CreateApiKeyData,
+} from "../../../../src/types/apiKeys";
 
 const validData: CreateApiKeyData = {
   name: `Service Account`,
@@ -79,6 +83,94 @@ tap.test(`Issue #36 — ApiKeys.create`, async t => {
     const response = await apiKeys.create(validData);
 
     tt.match(capturedRequest.args(), [[`api-keys`, validData, `POST`]]);
+    tt.equal(response.status, 403);
+    tt.end();
+  });
+});
+
+tap.test(`Issue #37 — ApiKeys.list`, async t => {
+  const listItem: ApiKeyListItem = {
+    api_key_id: `api_key_test_123`,
+    name: `Service Account`,
+    owner_id: `merchant_a`,
+    scopes: [`ledgers:read`],
+    expires_at: `2026-03-11T00:00:00Z`,
+    created_at: `2026-06-12T05:50:00.000Z`,
+    last_used_at: `0001-01-01T00:00:00Z`,
+    is_revoked: false,
+  };
+
+  t.test(`list GETs api-keys without owner filter`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: [listItem] as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.list();
+
+    tt.match(capturedRequest.args(), [[`api-keys`, undefined, `GET`]]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.length, 1);
+    tt.equal(response.data?.[0]?.api_key_id, `api_key_test_123`);
+    tt.end();
+  });
+
+  t.test(`list GETs api-keys?owner= when owner provided`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: [] as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.list({owner: `merchant_a`});
+
+    tt.match(capturedRequest.args(), [
+      [`api-keys?owner=merchant_a`, undefined, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.end();
+  });
+
+  t.test(`list returns 400 for empty owner`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: [] as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.list({owner: ``});
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /owner/);
+    tt.end();
+  });
+
+  t.test(`list forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 403,
+      message: `forbidden`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.list({owner: `merchant_a`});
+
+    tt.match(capturedRequest.args(), [
+      [`api-keys?owner=merchant_a`, undefined, `GET`],
+    ]);
     tt.equal(response.status, 403);
     tt.end();
   });

--- a/tests/unit/blnk/utils/apiKeyValidators.test.ts
+++ b/tests/unit/blnk/utils/apiKeyValidators.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
-import {ValidateCreateApiKeyData} from "../../../../src/blnk/utils/validators/apiKeyValidators";
+import {
+  ValidateCreateApiKeyData,
+  ValidateListApiKeysOptions,
+} from "../../../../src/blnk/utils/validators/apiKeyValidators";
 import {CreateApiKeyData} from "../../../../src/types/apiKeys";
 
 tap.test(`ValidateCreateApiKeyData`, async t => {
@@ -32,5 +35,13 @@ tap.test(`ValidateCreateApiKeyData`, async t => {
     ValidateCreateApiKeyData({...validData, expires_at: `not-a-date`}),
     /expires_at/,
   );
+  t.end();
+});
+
+tap.test(`ValidateListApiKeysOptions`, async t => {
+  t.equal(ValidateListApiKeysOptions(undefined), null);
+  t.equal(ValidateListApiKeysOptions({}), null);
+  t.equal(ValidateListApiKeysOptions({owner: `merchant_a`}), null);
+  t.match(ValidateListApiKeysOptions({owner: ``}), /owner/);
   t.end();
 });


### PR DESCRIPTION
## Summary
- Add `ApiKeys.list(options?)` calling `GET /api-keys` with optional `{ owner }` query param.
- Add `ListApiKeysOptions` and `ApiKeyListItem` types (`key` omitted from list responses per Core security behavior).
- Add `ValidateListApiKeysOptions` and endpoint + validator unit tests.
- Update README API Keys section with list example and endpoint map row.

## Test plan
- [x] `npm run test:unit` (774 passing)
- [x] `npm run lint` (pre-existing warnings only)
- [x] Postman **TS SDK (#37)** — create key (setup) → `GET /api-keys?owner=merchant_issue37` (200, array, no raw `key`)

Closes #37