### PR TITLE
Add ApiKeys.delete (DELETE /api-keys/{id}) (closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,8 +958,9 @@ See the [Delete hooks reference](https://docs.blnkfinance.com/reference/delete-h
 |--------|----------|----------|
 | `ApiKeys.create(data)` | `POST /api-keys` | Create a scoped API key |
 | `ApiKeys.list(options?)` | `GET /api-keys` | List API keys for an owner |
+| `ApiKeys.delete(id, options?)` | `DELETE /api-keys/{id}` | Revoke an API key |
 
-> API key management requires the **master key** or scoped permissions (`api-keys:write` to create, `api-keys:read` to list). The raw `key` value is only returned once at creation.
+> API key management requires the **master key** or scoped permissions (`api-keys:write` to create, `api-keys:read` to list, `api-keys:delete` to revoke). The raw `key` value is only returned once at creation.
 
 ### Create an API key
 
@@ -985,6 +986,15 @@ const keys = await ApiKeys.list({ owner: 'merchant_a' });
 ```
 
 See the [List API keys reference](https://docs.blnkfinance.com/reference/get-api-key).
+
+### Revoke an API key
+
+```typescript
+await ApiKeys.delete('api_key_abc123', { owner: 'merchant_a' });
+// 204 No Content on success; response.data is null
+```
+
+See the [Revoke API key reference](https://docs.blnkfinance.com/reference/delete-api-key).
 
 ---
 

--- a/src/blnk/endpoints/apiKeys.ts
+++ b/src/blnk/endpoints/apiKeys.ts
@@ -2,12 +2,14 @@ import {BlnkLogger} from "../../types/blnkClient";
 import {
   ApiKeyResp,
   CreateApiKeyData,
+  DeleteApiKeyOptions,
   ListApiKeysOptions,
 } from "../../types/apiKeys";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {HandleError} from "../utils/logger";
 import {
   ValidateCreateApiKeyData,
+  ValidateDeleteApiKeyOptions,
   ValidateListApiKeysOptions,
 } from "../utils/validators/apiKeyValidators";
 
@@ -88,6 +90,44 @@ export class ApiKeys {
         this.logger,
         this.formatResponse,
         this.list.name,
+      );
+    }
+  }
+
+  /**
+   * Revokes an API key by ID.
+   *
+   * @see https://docs.blnkfinance.com/reference/delete-api-key
+   */
+  async delete(id: string, options?: DeleteApiKeyOptions) {
+    try {
+      if (!id) {
+        return this.formatResponse(400, `api key id is required`, null);
+      }
+
+      const validatorResponse = ValidateDeleteApiKeyOptions(options);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      let endpoint = `api-keys/${encodeURIComponent(id)}`;
+      if (options?.owner !== undefined) {
+        endpoint += `?owner=${encodeURIComponent(options.owner)}`;
+      }
+
+      const response = await this.request<undefined, null>(
+        endpoint,
+        undefined,
+        `DELETE`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.delete.name,
       );
     }
   }

--- a/src/blnk/utils/validators/apiKeyValidators.ts
+++ b/src/blnk/utils/validators/apiKeyValidators.ts
@@ -1,4 +1,8 @@
-import {CreateApiKeyData, ListApiKeysOptions} from "../../../types/apiKeys";
+import {
+  CreateApiKeyData,
+  DeleteApiKeyOptions,
+  ListApiKeysOptions,
+} from "../../../types/apiKeys";
 import {IsValidArray, IsValidString} from "../stringUtils";
 import {isValidTransactionDateInput} from "../transactionSerialization";
 
@@ -56,4 +60,10 @@ export function ValidateListApiKeysOptions(
   }
 
   return null;
+}
+
+export function ValidateDeleteApiKeyOptions(
+  options?: DeleteApiKeyOptions,
+): string | null {
+  return ValidateListApiKeysOptions(options);
 }

--- a/src/types/apiKeys.ts
+++ b/src/types/apiKeys.ts
@@ -10,6 +10,10 @@ export interface ListApiKeysOptions {
   owner?: string;
 }
 
+export interface DeleteApiKeyOptions {
+  owner?: string;
+}
+
 export interface ApiKeyResp {
   api_key_id: string;
   key: string;

--- a/tests/unit/blnk/endpoints/apiKeys.test.ts
+++ b/tests/unit/blnk/endpoints/apiKeys.test.ts
@@ -195,3 +195,128 @@ tap.test(`Issue #37 — ApiKeys.list`, async t => {
     tt.end();
   });
 });
+
+tap.test(`Issue #38 — ApiKeys.delete`, async t => {
+  t.test(`delete DELETEs api-keys/{id}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 204,
+      message: `Success`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.delete(`api_key_test_123`);
+
+    tt.match(capturedRequest.args(), [
+      [`api-keys/api_key_test_123`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 204);
+    tt.equal(response.data, null);
+    tt.end();
+  });
+
+  t.test(`delete DELETEs api-keys/{id}?owner= when owner provided`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 204,
+      message: `Success`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.delete(`api_key_test_123`, {
+      owner: `merchant_a`,
+    });
+
+    tt.match(capturedRequest.args(), [
+      [`api-keys/api_key_test_123?owner=merchant_a`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 204);
+    tt.end();
+  });
+
+  t.test(`delete URL-encodes id and owner`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 204,
+      message: `Success`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.delete(`api/key?id=1`, {
+      owner: `merchant a&role=admin`,
+    });
+
+    tt.match(capturedRequest.args(), [
+      [
+        `api-keys/${encodeURIComponent(`api/key?id=1`)}?owner=${encodeURIComponent(`merchant a&role=admin`)}`,
+        undefined,
+        `DELETE`,
+      ],
+    ]);
+    tt.equal(response.status, 204);
+    tt.end();
+  });
+
+  t.test(`delete returns 400 for empty id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 204,
+      message: `Success`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.delete(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `api key id is required`);
+    tt.end();
+  });
+
+  t.test(`delete returns 400 for empty owner`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 204,
+      message: `Success`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.delete(`api_key_test_123`, {owner: ``});
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.match(response.message, /owner/);
+    tt.end();
+  });
+
+  t.test(`delete forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `API key not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await apiKeys.delete(`api_key_missing`, {
+      owner: `merchant_a`,
+    });
+
+    tt.match(capturedRequest.args(), [
+      [`api-keys/api_key_missing?owner=merchant_a`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/apiKeyValidators.test.ts
+++ b/tests/unit/blnk/utils/apiKeyValidators.test.ts
@@ -2,6 +2,7 @@
 import tap from "tap";
 import {
   ValidateCreateApiKeyData,
+  ValidateDeleteApiKeyOptions,
   ValidateListApiKeysOptions,
 } from "../../../../src/blnk/utils/validators/apiKeyValidators";
 import {CreateApiKeyData} from "../../../../src/types/apiKeys";
@@ -43,5 +44,12 @@ tap.test(`ValidateListApiKeysOptions`, async t => {
   t.equal(ValidateListApiKeysOptions({}), null);
   t.equal(ValidateListApiKeysOptions({owner: `merchant_a`}), null);
   t.match(ValidateListApiKeysOptions({owner: ``}), /owner/);
+  t.end();
+});
+
+tap.test(`ValidateDeleteApiKeyOptions`, async t => {
+  t.equal(ValidateDeleteApiKeyOptions(undefined), null);
+  t.equal(ValidateDeleteApiKeyOptions({owner: `merchant_a`}), null);
+  t.match(ValidateDeleteApiKeyOptions({owner: ``}), /owner/);
   t.end();
 });


### PR DESCRIPTION
## Summary
- Add `ApiKeys.delete(id, options?)` calling `DELETE /api-keys/{id}` with optional `{ owner }` query param (master key requires `owner`).
- Add `DeleteApiKeyOptions` and `ValidateDeleteApiKeyOptions`; URL-encode path `id` and `owner` query value.
- Add endpoint + validator unit tests and README API Keys section (revoke example + endpoint map row).

## Test plan
- [x] `npm run test:unit` (795 passing)
- [x] `npm run lint` (pre-existing warnings only)
- [x] Postman **TS SDK (#38)** — create key (setup) → `DELETE /api-keys/{id}?owner=merchant_issue38` (204 No Content)

Closes #38