### PR TITLE
Migrate from node-fetch to native fetch (closes #54)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,17 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "form-data": "^4.0.5",
-        "node-fetch": "^2.7.0"
+        "form-data": "^4.0.5"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
-        "@types/node-fetch": "^2.6.13",
         "gts": "^6.0.2",
         "prettier": "^3.8.1",
         "tap": "^21.6.2",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -260,23 +261,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@gar/promise-retry": {
@@ -1546,17 +1530,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -5098,26 +5071,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-gyp": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
@@ -5751,6 +5704,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7062,18 +7016,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -7342,29 +7284,6 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -26,17 +26,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "@types/node-fetch": "^2.6.13",
     "gts": "^6.0.2",
     "prettier": "^3.8.1",
     "tap": "^21.6.2",
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "form-data": "^4.0.5",
-    "node-fetch": "^2.7.0"
+    "form-data": "^4.0.5"
   },
   "overrides": {
     "whatwg-url": "^16.0.1",

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -5,6 +5,11 @@ import {
   ServiceInstances,
   ServicesMap,
 } from "../../types/general";
+import {
+  isNodeFormData,
+  isWebFormData,
+  nodeFormDataToFetchBody,
+} from "../utils/formDataBody";
 import {HandleError} from "../utils/logger";
 import {ApiKeys} from "./apiKeys";
 import {BalanceMonitor} from "./balanceMonitors";
@@ -17,8 +22,6 @@ import {Reconciliation} from "./reconciliation";
 import {Search} from "./search";
 import {System} from "./system";
 import {Transactions} from "./transactions";
-import FormData from "form-data";
-
 /**
  * Blnk class for interacting with the Blnk API services.
  *
@@ -95,15 +98,32 @@ export class Blnk {
     method: `POST` | `GET` | `PUT` | `DELETE`,
     headerOptions?: Record<string, string>,
   ): Promise<ApiResponse<R | null>> {
-    const headers = {
-      "content-type": `application/json`,
-      "X-Blnk-Key": this.apiKey,
-      ...headerOptions,
-    };
-
     const controller = new AbortController();
     const timeoutMs = this.options.timeout ?? 3000;
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    let body: BodyInit | undefined;
+    const formDataHeaders: Record<string, string> = {};
+
+    if (data) {
+      if (isNodeFormData(data)) {
+        const converted = nodeFormDataToFetchBody(data);
+        body = converted.body as BodyInit;
+        Object.assign(formDataHeaders, converted.headers);
+      } else if (isWebFormData(data)) {
+        body = data;
+      } else {
+        body = JSON.stringify(data);
+      }
+    }
+
+    const isMultipart = isNodeFormData(data) || isWebFormData(data);
+    const headers: Record<string, string> = {
+      "X-Blnk-Key": this.apiKey,
+      ...(!isMultipart ? {"content-type": `application/json`} : {}),
+      ...headerOptions,
+      ...formDataHeaders,
+    };
 
     try {
       const response = await this.thirdPartyRequest(
@@ -111,11 +131,7 @@ export class Blnk {
         {
           method,
           headers,
-          body: data
-            ? data instanceof FormData
-              ? (data as unknown as BodyInit)
-              : JSON.stringify(data)
-            : undefined,
+          body,
           signal: controller.signal,
         },
       );

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -7,6 +7,7 @@ import {
 } from "../../types/general";
 import {
   isNodeFormData,
+  isStreamingFetchBody,
   isWebFormData,
   nodeFormDataToFetchBody,
 } from "../utils/formDataBody";
@@ -125,15 +126,23 @@ export class Blnk {
       ...formDataHeaders,
     };
 
+    type FetchInitWithDuplex = RequestInit & {duplex?: `half`};
+
+    const fetchInit: FetchInitWithDuplex = {
+      method,
+      headers,
+      body,
+      signal: controller.signal,
+    };
+
+    if (isStreamingFetchBody(body)) {
+      fetchInit.duplex = `half`;
+    }
+
     try {
       const response = await this.thirdPartyRequest(
         `${this.options.baseUrl}${endpoint}`,
-        {
-          method,
-          headers,
-          body,
-          signal: controller.signal,
-        },
+        fetchInit,
       );
 
       if (!response.ok) {

--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -1,4 +1,4 @@
-import {BlnkClientOptions, BlnkLogger, fetchType} from "../../types/blnkClient";
+import {BlnkClientOptions, BlnkLogger, FetchType} from "../../types/blnkClient";
 import {
   ApiResponse,
   FormatResponseType,
@@ -46,14 +46,14 @@ export class Blnk {
   private services: ServicesMap;
   private serviceInstances: ServiceInstances = {}; // Cache initialized services
   private formatResponse: FormatResponseType;
-  private thirdPartyRequest: fetchType;
+  private thirdPartyRequest: FetchType;
 
   constructor(
     apiKey: string,
     options: BlnkClientOptions,
     services: ServicesMap,
     formatResponse: FormatResponseType,
-    thirdPartyRequest: fetchType,
+    thirdPartyRequest: FetchType,
   ) {
     if (!options.baseUrl) {
       throw new Error(`baseUrl is required for self-hosted Blnk SDK.`);
@@ -101,6 +101,10 @@ export class Blnk {
       ...headerOptions,
     };
 
+    const controller = new AbortController();
+    const timeoutMs = this.options.timeout ?? 3000;
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
     try {
       const response = await this.thirdPartyRequest(
         `${this.options.baseUrl}${endpoint}`,
@@ -109,10 +113,10 @@ export class Blnk {
           headers,
           body: data
             ? data instanceof FormData
-              ? data
+              ? (data as unknown as BodyInit)
               : JSON.stringify(data)
             : undefined,
-          timeout: this.options.timeout,
+          signal: controller.signal,
         },
       );
 
@@ -136,6 +140,15 @@ export class Blnk {
         jsonResponse,
       ) as ApiResponse<R>;
     } catch (error: unknown) {
+      if (error instanceof Error && error.name === `AbortError`) {
+        this.logger.error(`Request timed out`, {endpoint, timeoutMs});
+        return this.formatResponse(
+          408,
+          `Request timed out after ${timeoutMs}ms`,
+          null,
+        );
+      }
+
       this.logger.error(`Request failed`, {endpoint, error});
       return HandleError(
         error,
@@ -143,6 +156,8 @@ export class Blnk {
         this.formatResponse,
         `${this.request.name}`,
       );
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/src/blnk/endpoints/reconciliation.ts
+++ b/src/blnk/endpoints/reconciliation.ts
@@ -98,9 +98,6 @@ export class Reconciliation {
         `reconciliation/upload`,
         formData,
         `POST`,
-        {
-          "content-type": `multipart/form-data;boundary=${formData.getBoundary()}`,
-        },
       );
       return response;
     } catch (error) {

--- a/src/blnk/utils/formDataBody.ts
+++ b/src/blnk/utils/formDataBody.ts
@@ -1,0 +1,22 @@
+import FormDataNode from "form-data";
+
+export function isNodeFormData(data: unknown): data is FormDataNode {
+  return data instanceof FormDataNode;
+}
+
+export function isWebFormData(data: unknown): data is FormData {
+  return typeof FormData !== `undefined` && data instanceof FormData;
+}
+
+/**
+ * Converts the npm `form-data` payload to a body + headers native `fetch` accepts.
+ */
+export function nodeFormDataToFetchBody(formData: FormDataNode): {
+  body: Uint8Array;
+  headers: Record<string, string>;
+} {
+  return {
+    body: new Uint8Array(formData.getBuffer()),
+    headers: formData.getHeaders() as Record<string, string>,
+  };
+}

--- a/src/blnk/utils/formDataBody.ts
+++ b/src/blnk/utils/formDataBody.ts
@@ -13,6 +13,10 @@ export function isWebFormData(data: unknown): data is FormData {
  * Converts npm `form-data` (including stream-backed file parts) to a body
  * native `fetch` accepts.
  */
+export function isStreamingFetchBody(body: BodyInit | undefined): boolean {
+  return typeof ReadableStream !== `undefined` && body instanceof ReadableStream;
+}
+
 export function nodeFormDataToFetchBody(formData: FormDataNode): {
   body: ReadableStream<Uint8Array>;
   headers: Record<string, string>;

--- a/src/blnk/utils/formDataBody.ts
+++ b/src/blnk/utils/formDataBody.ts
@@ -1,4 +1,5 @@
 import FormDataNode from "form-data";
+import {PassThrough, Readable} from "node:stream";
 
 export function isNodeFormData(data: unknown): data is FormDataNode {
   return data instanceof FormDataNode;
@@ -9,14 +10,18 @@ export function isWebFormData(data: unknown): data is FormData {
 }
 
 /**
- * Converts the npm `form-data` payload to a body + headers native `fetch` accepts.
+ * Converts npm `form-data` (including stream-backed file parts) to a body
+ * native `fetch` accepts.
  */
 export function nodeFormDataToFetchBody(formData: FormDataNode): {
-  body: Uint8Array;
+  body: ReadableStream<Uint8Array>;
   headers: Record<string, string>;
 } {
+  const passthrough = new PassThrough();
+  formData.pipe(passthrough);
+
   return {
-    body: new Uint8Array(formData.getBuffer()),
+    body: Readable.toWeb(passthrough) as ReadableStream<Uint8Array>,
     headers: formData.getHeaders() as Record<string, string>,
   };
 }

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -57,7 +57,7 @@ export function ValidateTokenizeIdentityData(
   }
 
   for (const field of data.fields) {
-    if (!IsValidString(field) || field === ``) {
+    if (!IsValidString(field) || String(field).length === 0) {
       return `each field must be a non-empty string`;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import {Transactions} from "./blnk/endpoints/transactions";
 import {FormatResponse} from "./blnk/utils/httpClient";
 import {CustomLogger} from "./blnk/utils/logger";
 import {BlnkClientOptions} from "./types/blnkClient";
-import fetch from "node-fetch";
 //import {BlnkInitFn} from "./types/general";
 
 // Export a function to initialize the SDK with default logger handling
@@ -38,7 +37,7 @@ export function BlnkInit(apiKey: string, options: BlnkClientOptions) {
       ApiKeys,
     },
     FormatResponse,
-    fetch,
+    globalThis.fetch,
   );
 }
 //module.exports = BlnkInit as BlnkInitFn & {default: BlnkInitFn};

--- a/src/types/blnkClient.ts
+++ b/src/types/blnkClient.ts
@@ -1,7 +1,6 @@
-import {RequestInfo, Response, RequestInit} from "node-fetch";
 export interface BlnkClientOptions {
   baseUrl: string; // Required
-  timeout?: number; // Optional, default to a reasonable value like 30 seconds
+  timeout?: number; // Optional HTTP timeout in ms (default 3000)
   logger?: BlnkLogger;
 }
 
@@ -11,7 +10,5 @@ export interface BlnkLogger {
   debug?(message: string, ...meta: unknown[]): void; // Optional for more detailed logs
 }
 
-export type fetchType = (
-  input: RequestInfo,
-  init?: RequestInit,
-) => Promise<Response>;
+/** Platform fetch (Node 18+ global `fetch`). */
+export type FetchType = typeof fetch;

--- a/tests/mocks/fetchMock.ts
+++ b/tests/mocks/fetchMock.ts
@@ -1,57 +1,51 @@
 /* eslint-disable n/no-unpublished-import */
 // src/mocks/fetchMock.ts
 import t from "tap";
-import fetch, {RequestInfo, RequestInit, Headers, Response} from "node-fetch";
-export const fetchMock = t.createMock(
-  {fetch},
-  {
-    fetch: async (
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins
-      input: URL | RequestInfo,
-      init?: RequestInit,
-    ): Promise<Response> => {
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
-          message: `Success`,
-        }),
-        text: async () => `Mock text response`,
-        headers: new Headers(init?.headers), // Simulate headers if needed
-        statusText: `OK`,
-        url: input.toString(),
-        redirected: false,
-        type: `basic`,
-        body: null,
-        bodyUsed: false,
-      } as unknown as Response; // Cast to Response
-    },
-  },
-);
 
-export const fetchFailMock = t.createMock(
-  {fetch},
-  {
-    fetch: async (
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ): Promise<Response> => {
-      return {
-        ok: false,
-        status: 500,
-        json: async () => ({
-          message: `Failed`,
-        }),
-        text: async () => `Failed`,
-        headers: new Headers(init?.headers), // Simulate headers if needed
-        statusText: `Failed`,
-        url: input.toString(),
-        redirected: false,
-        type: `basic`,
-        body: null,
-        bodyUsed: false,
-      } as unknown as Response; // Cast to Response
-    },
+const fetchTarget = {fetch: globalThis.fetch};
+
+export const fetchMock = t.createMock(fetchTarget, {
+  fetch: async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        message: `Success`,
+      }),
+      text: async () => `Mock text response`,
+      headers: new Headers(init?.headers),
+      statusText: `OK`,
+      url: input.toString(),
+      redirected: false,
+      type: `basic`,
+      body: null,
+      bodyUsed: false,
+    } as unknown as Response;
   },
-);
+});
+
+export const fetchFailMock = t.createMock(fetchTarget, {
+  fetch: async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    return {
+      ok: false,
+      status: 500,
+      json: async () => ({
+        message: `Failed`,
+      }),
+      text: async () => `Failed`,
+      headers: new Headers(init?.headers),
+      statusText: `Failed`,
+      url: input.toString(),
+      redirected: false,
+      type: `basic`,
+      body: null,
+      bodyUsed: false,
+    } as unknown as Response;
+  },
+});

--- a/tests/mocks/streamTestUtils.ts
+++ b/tests/mocks/streamTestUtils.ts
@@ -1,0 +1,16 @@
+export async function readWebStreamBody(
+  body: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const {value, done} = await reader.read();
+    if (done) {
+      break;
+    }
+    if (value) {
+      chunks.push(value);
+    }
+  }
+  return Buffer.concat(chunks).toString(`utf8`);
+}

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -57,6 +57,61 @@ tap.test(`Blnk SDK tests`, t => {
     },
   );
 
+  t.test(`request passes AbortSignal for timeout`, async tt => {
+    const signalFetch = async (
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({message: `Success`}),
+        statusText: `OK`,
+      }) as Response;
+    const capturedFetch = tt.captureFn(signalFetch);
+    const signalBlnk = new Blnk(
+      apiKey,
+      options,
+      mockServices,
+      FormatResponse,
+      capturedFetch,
+    );
+
+    await signalBlnk[`request`](`/test`, {foo: `bar`}, `POST`);
+
+    const capturedInit = capturedFetch.calls[0]?.args[1] as
+      | RequestInit
+      | undefined;
+    tt.ok(capturedInit?.signal instanceof AbortSignal);
+    tt.end();
+  });
+
+  t.test(`request returns 408 when fetch aborts (timeout)`, async tt => {
+    const abortingFetch = async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener(`abort`, () => {
+          reject(new DOMException(`The operation was aborted.`, `AbortError`));
+        });
+      });
+
+    const timeoutBlnk = new Blnk(
+      apiKey,
+      {...options, timeout: 10},
+      mockServices,
+      FormatResponse,
+      abortingFetch,
+    );
+
+    const result = await timeoutBlnk[`request`](`/slow`, {foo: `bar`}, `POST`);
+
+    tt.equal(result.status, 408);
+    tt.match(result.message, /timed out/);
+    tt.end();
+  });
+
   t.test(
     `request method should make successful POST request and return formatted response`,
     async tt => {

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -96,6 +96,7 @@ tap.test(`Blnk SDK tests`, t => {
     const headers = init.headers as Record<string, string>;
     tt.match(headers[`content-type`], /multipart\/form-data/);
     tt.notMatch(headers[`content-type`], /application\/json/);
+    tt.equal((init as RequestInit & {duplex?: string}).duplex, `half`);
     tt.end();
   });
 
@@ -138,6 +139,7 @@ tap.test(`Blnk SDK tests`, t => {
       );
       tt.match(payload, /amount,ref/);
       tt.match(payload, /100,abc/);
+      tt.equal((init as RequestInit & {duplex?: string}).duplex, `half`);
       tt.end();
     },
   );
@@ -179,6 +181,7 @@ tap.test(`Blnk SDK tests`, t => {
       );
       tt.match(payload, /stripe/);
       tt.match(payload, /200,xyz/);
+      tt.equal((init as RequestInit & {duplex?: string}).duplex, `half`);
       tt.end();
     },
   );

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../mocks/blnkClientMocks";
 import {BlnkClientOptions} from "../../../../src/types/blnkClient";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import FormDataNode from "form-data";
 
 tap.test(`Blnk SDK tests`, t => {
   const options: BlnkClientOptions = createMockBlnkClientOptions();
@@ -56,6 +57,38 @@ tap.test(`Blnk SDK tests`, t => {
       );
     },
   );
+
+  t.test(`request converts npm FormData for native fetch`, async tt => {
+    const formData = new FormDataNode();
+    formData.append(`source`, `stripe`);
+    formData.append(`file`, Buffer.from(`a,b,c`), {filename: `test.csv`});
+
+    const capturedFetch = tt.captureFn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        ({
+          ok: true,
+          status: 201,
+          json: async () => ({upload_id: `upl_test`}),
+          statusText: `Created`,
+        }) as Response,
+    );
+    const formBlnk = new Blnk(
+      apiKey,
+      options,
+      mockServices,
+      FormatResponse,
+      capturedFetch,
+    );
+
+    await formBlnk[`request`](`reconciliation/upload`, formData, `POST`);
+
+    const init = capturedFetch.calls[0]?.args[1] as RequestInit;
+    tt.ok(init.body instanceof Uint8Array);
+    const headers = init.headers as Record<string, string>;
+    tt.match(headers[`content-type`], /multipart\/form-data/);
+    tt.notMatch(headers[`content-type`], /application\/json/);
+    tt.end();
+  });
 
   t.test(`request passes AbortSignal for timeout`, async tt => {
     const signalFetch = async (

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -9,6 +9,11 @@ import {
 import {BlnkClientOptions} from "../../../../src/types/blnkClient";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
 import FormDataNode from "form-data";
+import {createReadStream, mkdtempSync, writeFileSync} from "fs";
+import {tmpdir} from "os";
+import {join} from "path";
+import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
+import {readWebStreamBody} from "../../../mocks/streamTestUtils";
 
 tap.test(`Blnk SDK tests`, t => {
   const options: BlnkClientOptions = createMockBlnkClientOptions();
@@ -83,12 +88,100 @@ tap.test(`Blnk SDK tests`, t => {
     await formBlnk[`request`](`reconciliation/upload`, formData, `POST`);
 
     const init = capturedFetch.calls[0]?.args[1] as RequestInit;
-    tt.ok(init.body instanceof Uint8Array);
+    tt.ok(init.body instanceof ReadableStream);
+    const payload = await readWebStreamBody(
+      init.body as ReadableStream<Uint8Array>,
+    );
+    tt.match(payload, /a,b,c/);
     const headers = init.headers as Record<string, string>;
     tt.match(headers[`content-type`], /multipart\/form-data/);
     tt.notMatch(headers[`content-type`], /application\/json/);
     tt.end();
   });
+
+  t.test(
+    `request converts stream-backed npm FormData for native fetch`,
+    async tt => {
+      const dir = mkdtempSync(join(tmpdir(), `blnk-upload-`));
+      const filePath = join(dir, `upload.csv`);
+      writeFileSync(filePath, `amount,ref\n100,abc`);
+
+      const formData = new FormDataNode();
+      formData.append(`source`, `stripe`);
+      formData.append(`file`, createReadStream(filePath), {
+        filename: `upload.csv`,
+      });
+
+      const capturedFetch = tt.captureFn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          ({
+            ok: true,
+            status: 201,
+            json: async () => ({upload_id: `upl_test`}),
+            statusText: `Created`,
+          }) as Response,
+      );
+      const formBlnk = new Blnk(
+        apiKey,
+        options,
+        mockServices,
+        FormatResponse,
+        capturedFetch,
+      );
+
+      await formBlnk[`request`](`reconciliation/upload`, formData, `POST`);
+
+      const init = capturedFetch.calls[0]?.args[1] as RequestInit;
+      tt.ok(init.body instanceof ReadableStream);
+      const payload = await readWebStreamBody(
+        init.body as ReadableStream<Uint8Array>,
+      );
+      tt.match(payload, /amount,ref/);
+      tt.match(payload, /100,abc/);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `reconciliation.upload sends stream multipart body through native fetch`,
+    async tt => {
+      const dir = mkdtempSync(join(tmpdir(), `blnk-recon-upload-`));
+      const filePath = join(dir, `upload.csv`);
+      writeFileSync(filePath, `amount,ref\n200,xyz`);
+
+      const capturedFetch = tt.captureFn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          ({
+            ok: true,
+            status: 201,
+            json: async () => ({upload_id: `upl_test`}),
+            statusText: `Created`,
+          }) as Response,
+      );
+      const uploadBlnk = new Blnk(
+        apiKey,
+        options,
+        {...mockServices, Reconciliation},
+        FormatResponse,
+        capturedFetch,
+      );
+
+      const response = await uploadBlnk.Reconciliation.upload(
+        filePath,
+        `stripe`,
+      );
+
+      tt.equal(response.status, 201);
+      const init = capturedFetch.calls[0]?.args[1] as RequestInit;
+      tt.ok(init.body instanceof ReadableStream);
+      const payload = await readWebStreamBody(
+        init.body as ReadableStream<Uint8Array>,
+      );
+      tt.match(payload, /stripe/);
+      tt.match(payload, /200,xyz/);
+      tt.end();
+    },
+  );
 
   t.test(`request passes AbortSignal for timeout`, async tt => {
     const signalFetch = async (
@@ -116,6 +209,26 @@ tap.test(`Blnk SDK tests`, t => {
       | RequestInit
       | undefined;
     tt.ok(capturedInit?.signal instanceof AbortSignal);
+    tt.end();
+  });
+
+  t.test(`request returns 408 when fetch aborts immediately`, async tt => {
+    const abortingFetch = async (): Promise<Response> => {
+      throw new DOMException(`The operation was aborted.`, `AbortError`);
+    };
+
+    const abortBlnk = new Blnk(
+      apiKey,
+      options,
+      mockServices,
+      FormatResponse,
+      abortingFetch,
+    );
+
+    const result = await abortBlnk[`request`](`/slow`, {foo: `bar`}, `POST`);
+
+    tt.equal(result.status, 408);
+    tt.match(result.message, /timed out/);
     tt.end();
   });
 

--- a/tests/unit/blnk/utils/formDataBody.test.ts
+++ b/tests/unit/blnk/utils/formDataBody.test.ts
@@ -1,10 +1,14 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
 import FormDataNode from "form-data";
+import {createReadStream, mkdtempSync, writeFileSync} from "fs";
+import {tmpdir} from "os";
+import {join} from "path";
 import {
   isNodeFormData,
   nodeFormDataToFetchBody,
 } from "../../../../src/blnk/utils/formDataBody";
+import {readWebStreamBody} from "../../../mocks/streamTestUtils";
 
 tap.test(`formDataBody`, async t => {
   t.test(`isNodeFormData identifies npm form-data instances`, tt => {
@@ -14,7 +18,7 @@ tap.test(`formDataBody`, async t => {
   });
 
   t.test(
-    `nodeFormDataToFetchBody returns Buffer and multipart headers`,
+    `nodeFormDataToFetchBody returns ReadableStream for buffer-backed parts`,
     async tt => {
       const formData = new FormDataNode();
       formData.append(`source`, `stripe`);
@@ -22,8 +26,35 @@ tap.test(`formDataBody`, async t => {
 
       const {body, headers} = nodeFormDataToFetchBody(formData);
 
-      tt.ok(body instanceof Uint8Array);
-      tt.ok(body.length > 0);
+      tt.ok(body instanceof ReadableStream);
+      const payload = await readWebStreamBody(body);
+      tt.match(payload, /stripe/);
+      tt.match(payload, /a,b,c/);
+      tt.match(headers[`content-type`], /multipart\/form-data/);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `nodeFormDataToFetchBody returns ReadableStream for file stream parts`,
+    async tt => {
+      const dir = mkdtempSync(join(tmpdir(), `blnk-formdata-`));
+      const filePath = join(dir, `upload.csv`);
+      writeFileSync(filePath, `amount,ref\n100,abc`);
+
+      const formData = new FormDataNode();
+      formData.append(`source`, `stripe`);
+      formData.append(`file`, createReadStream(filePath), {
+        filename: `upload.csv`,
+      });
+
+      const {body, headers} = nodeFormDataToFetchBody(formData);
+
+      tt.ok(body instanceof ReadableStream);
+      const payload = await readWebStreamBody(body);
+      tt.match(payload, /stripe/);
+      tt.match(payload, /amount,ref/);
+      tt.match(payload, /100,abc/);
       tt.match(headers[`content-type`], /multipart\/form-data/);
       tt.end();
     },

--- a/tests/unit/blnk/utils/formDataBody.test.ts
+++ b/tests/unit/blnk/utils/formDataBody.test.ts
@@ -2,6 +2,7 @@
 import tap from "tap";
 import FormDataNode from "form-data";
 import {createReadStream, mkdtempSync, writeFileSync} from "fs";
+import {createServer} from "http";
 import {tmpdir} from "os";
 import {join} from "path";
 import {
@@ -56,6 +57,70 @@ tap.test(`formDataBody`, async t => {
       tt.match(payload, /amount,ref/);
       tt.match(payload, /100,abc/);
       tt.match(headers[`content-type`], /multipart\/form-data/);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `native fetch accepts stream multipart body when duplex is half`,
+    async tt => {
+      const dir = mkdtempSync(join(tmpdir(), `blnk-native-fetch-`));
+      const filePath = join(dir, `upload.csv`);
+      writeFileSync(filePath, `amount,ref\n300,native`);
+
+      const formData = new FormDataNode();
+      formData.append(`source`, `stripe`);
+      formData.append(`file`, createReadStream(filePath), {
+        filename: `upload.csv`,
+      });
+      const {body, headers} = nodeFormDataToFetchBody(formData);
+
+      const server = createServer((req, res) => {
+        let payload = ``;
+        req.on(`data`, chunk => {
+          payload += chunk.toString();
+        });
+        req.on(`end`, () => {
+          res.writeHead(201, {"Content-Type": `application/json`});
+          res.end(
+            JSON.stringify({
+              ok: payload.includes(`stripe`) && payload.includes(`300,native`),
+            }),
+          );
+        });
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server.listen(0, async () => {
+          try {
+            const address = server.address();
+            if (!address || typeof address === `string`) {
+              throw new Error(`Expected server to listen on a TCP port`);
+            }
+
+            const fetchInit: RequestInit & {duplex?: `half`} = {
+              method: `POST`,
+              headers: headers as HeadersInit,
+              body,
+              duplex: `half`,
+            };
+            const response = await globalThis.fetch(
+              `http://127.0.0.1:${address.port}/upload`,
+              fetchInit,
+            );
+
+            tt.equal(response.status, 201);
+            const json = (await response.json()) as {ok: boolean};
+            tt.ok(json.ok);
+            resolve();
+          } catch (error) {
+            reject(error);
+          } finally {
+            server.close();
+          }
+        });
+      });
+
       tt.end();
     },
   );

--- a/tests/unit/blnk/utils/formDataBody.test.ts
+++ b/tests/unit/blnk/utils/formDataBody.test.ts
@@ -1,0 +1,31 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import FormDataNode from "form-data";
+import {
+  isNodeFormData,
+  nodeFormDataToFetchBody,
+} from "../../../../src/blnk/utils/formDataBody";
+
+tap.test(`formDataBody`, async t => {
+  t.test(`isNodeFormData identifies npm form-data instances`, tt => {
+    tt.ok(isNodeFormData(new FormDataNode()));
+    tt.notOk(isNodeFormData({}));
+    tt.end();
+  });
+
+  t.test(
+    `nodeFormDataToFetchBody returns Buffer and multipart headers`,
+    async tt => {
+      const formData = new FormDataNode();
+      formData.append(`source`, `stripe`);
+      formData.append(`file`, Buffer.from(`a,b,c`), {filename: `test.csv`});
+
+      const {body, headers} = nodeFormDataToFetchBody(formData);
+
+      tt.ok(body instanceof Uint8Array);
+      tt.ok(body.length > 0);
+      tt.match(headers[`content-type`], /multipart\/form-data/);
+      tt.end();
+    },
+  );
+});

--- a/tests/unit/blnk/utils/identityTokenizeValidators.test.ts
+++ b/tests/unit/blnk/utils/identityTokenizeValidators.test.ts
@@ -19,7 +19,7 @@ tap.test(`ValidateTokenizeIdentityData`, async t => {
   );
   t.equal(
     ValidateTokenizeIdentityData(`idt_test_123`, {
-      fields: [`FirstName`, ``],
+      fields: [`FirstName`, `` as `FirstName`],
     }),
     `each field must be a non-empty string`,
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Summary
- Remove `node-fetch` and `@types/node-fetch`; use Node 18+ global `fetch`.
- Replace node-fetch `timeout` option with `AbortController` + `AbortSignal` per request.
- Update `FetchType` to standard `Request` / `Response` / `RequestInit` types.
- Add `engines.node: ">=18"` to match install docs.
- Return **408** with a clear message when a request times out (`AbortError`).

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (798 passing)
- [x] `npm run lint` (pre-existing warnings only)
- [x] New tests: `AbortSignal` passed on requests; timeout returns 408

Closes #54