### PR TITLE
Security: remove public getApiKey getter (closes #55)

### DIFF
--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -323,8 +323,4 @@ export class Blnk {
   get ApiKeys(): ApiKeys {
     return this.getService<ApiKeys>(`ApiKeys`);
   }
-
-  get getApiKey() {
-    return this.apiKey;
-  }
 }

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -48,6 +48,17 @@ tap.test(`Blnk SDK tests`, t => {
     });
   });
 
+  t.test(`Issue #55 — does not expose public getApiKey getter`, async tt => {
+    tt.equal(
+      Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(blnk),
+        `getApiKey`,
+      ),
+      undefined,
+    );
+    tt.end();
+  });
+
   t.test(
     `Constructor should set apiKey, options, logger, services, and formatResponse correctly`,
     async tt => {


### PR DESCRIPTION
## Summary
- Removes the public `get getApiKey()` getter from `Blnk` so API keys are not exposed via debuggers, REPL inspection, or accidental logging
- API key remains private on the client and is still sent as `X-Blnk-Key` on requests

## Acceptance criteria
- [x] Remove public getter (no usages in repo; getter was unused)
- [x] No changelog entry (not required per issue when removed)

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` — 879 passing
- [x] Unit test asserts `getApiKey` is not on the client prototype