### PR TITLE
Security: omit X-Blnk-Key header when API key is empty (closes #56)

### DIFF
--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -141,7 +141,7 @@ export class Blnk {
     const canRetry =
       !isMultipart && maxAttempts > 1 && isRetryableHttpMethod(method);
     const headers: Record<string, string> = {
-      "X-Blnk-Key": this.apiKey,
+      ...(this.apiKey !== `` ? {"X-Blnk-Key": this.apiKey} : {}),
       ...(!isMultipart ? {"content-type": `application/json`} : {}),
       ...headerOptions,
       ...formDataHeaders,

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -48,6 +48,42 @@ tap.test(`Blnk SDK tests`, t => {
     });
   });
 
+  t.test(`Issue #56 — omits X-Blnk-Key for local unauthenticated mode`, async tt => {
+    const capturedFetch = tt.captureFn(fetchMock.fetch);
+    const localBlnk = new Blnk(
+      ``,
+      options,
+      mockServices,
+      FormatResponse,
+      capturedFetch,
+    );
+
+    await localBlnk[`request`](`health`, {}, `GET`);
+
+    const init = capturedFetch.calls[0]?.args[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    tt.notOk(`X-Blnk-Key` in headers);
+    tt.end();
+  });
+
+  t.test(`Issue #56 — sends X-Blnk-Key when api key is set`, async tt => {
+    const capturedFetch = tt.captureFn(fetchMock.fetch);
+    const authedBlnk = new Blnk(
+      apiKey,
+      options,
+      mockServices,
+      FormatResponse,
+      capturedFetch,
+    );
+
+    await authedBlnk[`request`](`health`, {}, `GET`);
+
+    const init = capturedFetch.calls[0]?.args[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    tt.equal(headers[`X-Blnk-Key`], apiKey);
+    tt.end();
+  });
+
   t.test(`Issue #55 — does not expose public getApiKey getter`, async tt => {
     tt.equal(
       Object.getOwnPropertyDescriptor(


### PR DESCRIPTION
## Summary
- Skip `X-Blnk-Key` when `BlnkInit` is called with an empty string API key (local unauthenticated mode per install docs)
- Continue sending the header when a non-empty key is provided

## Acceptance criteria
- [x] Skip header when apiKey is empty string
- [x] Test local unauthenticated mode

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` — 883 passing
- [x] Unit tests for empty-key omission and non-empty key inclusion