### PR TITLE
Security: safe logging — redact API key and audit error meta (closes #58)

### DIFF
--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -18,6 +18,7 @@ import {
   nodeFormDataToFetchBody,
 } from "../utils/formDataBody";
 import {HandleError} from "../utils/logger";
+import {redactSensitiveLogMeta, safeLogMeta} from "../utils/safeLogMeta";
 import {
   isRetryableFetchError,
   isRetryableHttpMethod,
@@ -215,7 +216,10 @@ export class Blnk {
       } catch (error: unknown) {
         if (error instanceof Error && error.name === `AbortError`) {
           // Timeouts are intentionally not retried to avoid duplicate mutating calls.
-          this.logger.error(`Request timed out`, {endpoint, timeoutMs});
+          this.logger.error(
+            `Request timed out`,
+            redactSensitiveLogMeta({endpoint, timeoutMs}),
+          );
           return this.formatResponse(
             408,
             `Request timed out after ${timeoutMs}ms`,
@@ -224,13 +228,17 @@ export class Blnk {
         }
 
         if (canRetry && isRetryableFetchError(error) && attempt < maxAttempts) {
-          this.logger.info(`Request to ${endpoint} failed; retrying.`, {
-            error,
-          });
+          this.logger.info(
+            `Request to ${endpoint} failed; retrying.`,
+            ...safeLogMeta(error),
+          );
           continue;
         }
 
-        this.logger.error(`Request failed`, {endpoint, error});
+        this.logger.error(
+          `Request failed`,
+          redactSensitiveLogMeta({endpoint, error}),
+        );
         return HandleError(
           error,
           this.logger,

--- a/src/blnk/endpoints/transactions.ts
+++ b/src/blnk/endpoints/transactions.ts
@@ -97,8 +97,6 @@ export class Transactions {
       >(`transactions`, payload, `POST`);
 
       if (response.data === null) {
-        // Handle the error case
-        this.logger.error(`error heree`);
         return response;
       }
 
@@ -485,8 +483,6 @@ export class Transactions {
       >(`transactions/bulk`, payload, `POST`);
 
       if (response.data === null) {
-        // Handle the error case
-        this.logger.error(`Error processing bulk transactions`);
         return response;
       }
 

--- a/src/blnk/utils/logger.ts
+++ b/src/blnk/utils/logger.ts
@@ -1,5 +1,6 @@
 import {BlnkLogger} from "../../types/blnkClient";
 import {ApiResponse, FormatResponseType} from "../../types/general";
+import {safeLogMeta} from "./safeLogMeta";
 
 export const CustomLogger: BlnkLogger = {
   info: (message: string, ...meta: unknown[]) => {
@@ -19,7 +20,7 @@ export function HandleError(
   formatResponse: FormatResponseType,
   fnName: string,
 ): ApiResponse<null> {
-  logger.error(fnName, error);
+  logger.error(fnName, ...safeLogMeta(error));
   if (error instanceof Error) {
     return formatResponse(500, error.message, null);
   } else {

--- a/src/blnk/utils/safeLogMeta.ts
+++ b/src/blnk/utils/safeLogMeta.ts
@@ -1,0 +1,70 @@
+const SENSITIVE_KEYS = new Set([
+  `apikey`,
+  `api_key`,
+  `x-blnk-key`,
+  `authorization`,
+  `cookie`,
+  `password`,
+  `secret`,
+  `token`,
+]);
+
+export function redactSensitiveString(value: string): string {
+  return value
+    .replace(/X-Blnk-Key:\s*[^\s,;]+/gi, `X-Blnk-Key: [REDACTED]`)
+    .replace(/Bearer\s+[^\s,;]+/gi, `Bearer [REDACTED]`)
+    .replace(/(api[_-]?key["']?\s*[:=]\s*["']?)[^"'\s,}]+/gi, `$1[REDACTED]`);
+}
+
+export function redactSensitiveLogValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === `string`) {
+    return redactSensitiveString(value);
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactSensitiveString(value.message),
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(redactSensitiveLogValue);
+  }
+
+  if (typeof value === `object`) {
+    return redactSensitiveLogMeta(value as Record<string, unknown>);
+  }
+
+  return value;
+}
+
+export function redactSensitiveLogMeta(
+  meta: Record<string, unknown>,
+): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(meta)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      redacted[key] = `[REDACTED]`;
+      continue;
+    }
+
+    if (key.toLowerCase() === `headers`) {
+      redacted[key] = redactSensitiveLogMeta(value as Record<string, unknown>);
+      continue;
+    }
+
+    redacted[key] = redactSensitiveLogValue(value);
+  }
+
+  return redacted;
+}
+
+export function safeLogMeta(...meta: unknown[]): unknown[] {
+  return meta.map(redactSensitiveLogValue);
+}

--- a/tests/unit/blnk/utils/logger.test.ts
+++ b/tests/unit/blnk/utils/logger.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {HandleError} from "../../../../src/blnk/utils/logger";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+
+tap.test(`HandleError`, t => {
+  t.test(`redacts sensitive values before logging`, tt => {
+    const logged: unknown[][] = [];
+    const logger = {
+      info: () => undefined,
+      error: (_message: string, ...meta: unknown[]) => {
+        logged.push(meta);
+      },
+    };
+
+    HandleError(
+      new Error(`failed with X-Blnk-Key: blnk_secret`),
+      logger,
+      FormatResponse,
+      `create`,
+    );
+
+    tt.same(logged[0], [
+      {name: `Error`, message: `failed with X-Blnk-Key: [REDACTED]`},
+    ]);
+    tt.end();
+  });
+
+  t.end();
+});

--- a/tests/unit/blnk/utils/safeLogMeta.test.ts
+++ b/tests/unit/blnk/utils/safeLogMeta.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {
+  redactSensitiveLogMeta,
+  redactSensitiveLogValue,
+  redactSensitiveString,
+  safeLogMeta,
+} from "../../../../src/blnk/utils/safeLogMeta";
+
+tap.test(`safeLogMeta`, t => {
+  t.test(`redacts auth header values in strings`, tt => {
+    const input = `Request failed with X-Blnk-Key: blnk_local_dev_secret`;
+    tt.equal(
+      redactSensitiveString(input),
+      `Request failed with X-Blnk-Key: [REDACTED]`,
+    );
+    tt.end();
+  });
+
+  t.test(`redacts sensitive object keys`, tt => {
+    const redacted = redactSensitiveLogMeta({
+      endpoint: `health`,
+      apiKey: `blnk_secret`,
+      headers: {
+        "X-Blnk-Key": `blnk_secret`,
+        "content-type": `application/json`,
+      },
+    });
+
+    tt.equal(redacted.apiKey, `[REDACTED]`);
+    tt.same(redacted.headers, {
+      "X-Blnk-Key": `[REDACTED]`,
+      "content-type": `application/json`,
+    });
+    tt.end();
+  });
+
+  t.test(`redacts Error objects to name and message only`, tt => {
+    const redacted = redactSensitiveLogValue(
+      new Error(`fetch failed with X-Blnk-Key: blnk_secret`),
+    );
+
+    tt.same(redacted, {
+      name: `Error`,
+      message: `fetch failed with X-Blnk-Key: [REDACTED]`,
+    });
+    tt.end();
+  });
+
+  t.test(`safeLogMeta sanitizes mixed metadata`, tt => {
+    const [errorMeta] = safeLogMeta({
+      endpoint: `transactions`,
+      error: new Error(`network error`),
+      authorization: `Bearer abc123`,
+    });
+
+    tt.same(errorMeta, {
+      endpoint: `transactions`,
+      error: {name: `Error`, message: `network error`},
+      authorization: `[REDACTED]`,
+    });
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `safeLogMeta` helpers to redact API keys, auth headers, tokens, and similar sensitive values from log metadata and error messages.
- Wire redaction into `HandleError` and HTTP failure/retry logs in `baseBlnkClient`.
- Remove ad-hoc `error heree` / bulk transaction error logs from `transactions.ts` (HTTP layer already logs failures).

## Acceptance criteria
- [x] Never log API key or auth headers
- [x] Review `HandleError` and HTTP failure logs
- [x] Remove ad-hoc logs like `error heree` in transactions

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (889 tests)