### PR TITLE
Fix 204 No Content parsing in shared request layer (closes #110)

### DIFF
--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -93,7 +93,9 @@ export class Blnk {
       ...restOptions,
     };
     this.options.retryCount = normalizeRetryCount(this.options.retryCount);
-    this.options.retryDelayMs = normalizeRetryDelayMs(this.options.retryDelayMs);
+    this.options.retryDelayMs = normalizeRetryDelayMs(
+      this.options.retryDelayMs,
+    );
 
     if (logger === undefined) {
       this.logger = console;
@@ -205,6 +207,14 @@ export class Blnk {
             errorResult,
             structuredError,
           );
+        }
+
+        if (response.status === 204 || response.status === 205) {
+          return this.formatResponse<R>(
+            response.status,
+            `Success`,
+            null as R,
+          ) as ApiResponse<R>;
         }
 
         const jsonResponse = (await response.json()) as R;

--- a/tests/unit/blnk/endpoints/apiKeys.test.ts
+++ b/tests/unit/blnk/endpoints/apiKeys.test.ts
@@ -1,8 +1,12 @@
 /* eslint-disable n/no-unpublished-import */
 import tap from "tap";
 import {ApiKeys} from "../../../../src/blnk/endpoints/apiKeys";
+import {Blnk} from "../../../../src/blnk/endpoints/baseBlnkClient";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
-import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {
+  createMockBlnkClientOptions,
+  createMockLogger,
+} from "../../../mocks/blnkClientMocks";
 import {ApiKeyResp, CreateApiKeyData} from "../../../../src/types/apiKeys";
 
 const validData: CreateApiKeyData = {
@@ -217,26 +221,29 @@ tap.test(`Issue #38 — ApiKeys.delete`, async t => {
     tt.end();
   });
 
-  t.test(`delete DELETEs api-keys/{id}?owner= when owner provided`, async tt => {
-    const mockLogger = createMockLogger();
-    const thirdPartyRequest = async <R>() => ({
-      status: 204,
-      message: `Success`,
-      data: null as R | null,
-    });
-    const capturedRequest = tt.captureFn(thirdPartyRequest);
-    const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
+  t.test(
+    `delete DELETEs api-keys/{id}?owner= when owner provided`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 204,
+        message: `Success`,
+        data: null as R | null,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const apiKeys = new ApiKeys(capturedRequest, mockLogger, FormatResponse);
 
-    const response = await apiKeys.delete(`api_key_test_123`, {
-      owner: `merchant_a`,
-    });
+      const response = await apiKeys.delete(`api_key_test_123`, {
+        owner: `merchant_a`,
+      });
 
-    tt.match(capturedRequest.args(), [
-      [`api-keys/api_key_test_123?owner=merchant_a`, undefined, `DELETE`],
-    ]);
-    tt.equal(response.status, 204);
-    tt.end();
-  });
+      tt.match(capturedRequest.args(), [
+        [`api-keys/api_key_test_123?owner=merchant_a`, undefined, `DELETE`],
+      ]);
+      tt.equal(response.status, 204);
+      tt.end();
+    },
+  );
 
   t.test(`delete URL-encodes id and owner`, async tt => {
     const mockLogger = createMockLogger();
@@ -319,4 +326,36 @@ tap.test(`Issue #38 — ApiKeys.delete`, async t => {
     tt.equal(response.status, 404);
     tt.end();
   });
+
+  t.test(
+    `Issue #110 — delete succeeds through request layer on 204 No Content`,
+    async tt => {
+      const noContentFetch = async () =>
+        ({
+          ok: true,
+          status: 204,
+          statusText: `No Content`,
+          json: async () => {
+            throw new SyntaxError(`Unexpected end of JSON input`);
+          },
+          text: async () => ``,
+          headers: new Headers(),
+        }) as unknown as Response;
+
+      const blnk = new Blnk(
+        `test-key`,
+        createMockBlnkClientOptions(),
+        {ApiKeys},
+        FormatResponse,
+        noContentFetch,
+      );
+
+      const response = await blnk.ApiKeys.delete(`api_key_test_123`);
+
+      tt.equal(response.status, 204);
+      tt.equal(response.message, `Success`);
+      tt.equal(response.data, null);
+      tt.end();
+    },
+  );
 });

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -48,23 +48,26 @@ tap.test(`Blnk SDK tests`, t => {
     });
   });
 
-  t.test(`Issue #56 — omits X-Blnk-Key for local unauthenticated mode`, async tt => {
-    const capturedFetch = tt.captureFn(fetchMock.fetch);
-    const localBlnk = new Blnk(
-      ``,
-      options,
-      mockServices,
-      FormatResponse,
-      capturedFetch,
-    );
+  t.test(
+    `Issue #56 — omits X-Blnk-Key for local unauthenticated mode`,
+    async tt => {
+      const capturedFetch = tt.captureFn(fetchMock.fetch);
+      const localBlnk = new Blnk(
+        ``,
+        options,
+        mockServices,
+        FormatResponse,
+        capturedFetch,
+      );
 
-    await localBlnk[`request`](`health`, {}, `GET`);
+      await localBlnk[`request`](`health`, {}, `GET`);
 
-    const init = capturedFetch.calls[0]?.args[1] as RequestInit;
-    const headers = init.headers as Record<string, string>;
-    tt.notOk(`X-Blnk-Key` in headers);
-    tt.end();
-  });
+      const init = capturedFetch.calls[0]?.args[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      tt.notOk(`X-Blnk-Key` in headers);
+      tt.end();
+    },
+  );
 
   t.test(`Issue #56 — sends X-Blnk-Key when api key is set`, async tt => {
     const capturedFetch = tt.captureFn(fetchMock.fetch);
@@ -86,10 +89,7 @@ tap.test(`Blnk SDK tests`, t => {
 
   t.test(`Issue #55 — does not expose public getApiKey getter`, async tt => {
     tt.equal(
-      Object.getOwnPropertyDescriptor(
-        Object.getPrototypeOf(blnk),
-        `getApiKey`,
-      ),
+      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(blnk), `getApiKey`),
       undefined,
     );
     tt.end();
@@ -229,6 +229,42 @@ tap.test(`Blnk SDK tests`, t => {
       tt.match(payload, /stripe/);
       tt.match(payload, /200,xyz/);
       tt.equal((init as RequestInit & {duplex?: string}).duplex, `half`);
+      tt.end();
+    },
+  );
+
+  t.test(
+    `Issue #110 — returns success for 204 No Content without parsing JSON`,
+    async tt => {
+      const noContentFetch = async () =>
+        ({
+          ok: true,
+          status: 204,
+          statusText: `No Content`,
+          json: async () => {
+            throw new SyntaxError(`Unexpected end of JSON input`);
+          },
+          text: async () => ``,
+          headers: new Headers(),
+        }) as unknown as Response;
+
+      const noContentBlnk = new Blnk(
+        apiKey,
+        options,
+        mockServices,
+        FormatResponse,
+        noContentFetch,
+      );
+
+      const response = await noContentBlnk[`request`](
+        `api-keys/api_key_test_123`,
+        undefined,
+        `DELETE`,
+      );
+
+      tt.equal(response.status, 204);
+      tt.equal(response.message, `Success`);
+      tt.equal(response.data, null);
       tt.end();
     },
   );
@@ -474,33 +510,38 @@ tap.test(`Blnk SDK tests`, t => {
     tt.end();
   });
 
-  t.test(`request does not retry timeouts even when retryCount > 1`, async tt => {
-    let calls = 0;
-    const timeoutFetch = async (
-      _input: RequestInfo | URL,
-      init?: RequestInit,
-    ): Promise<Response> =>
-      new Promise((_resolve, reject) => {
-        calls += 1;
-        init?.signal?.addEventListener(`abort`, () => {
-          reject(new DOMException(`The operation was aborted.`, `AbortError`));
+  t.test(
+    `request does not retry timeouts even when retryCount > 1`,
+    async tt => {
+      let calls = 0;
+      const timeoutFetch = async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          calls += 1;
+          init?.signal?.addEventListener(`abort`, () => {
+            reject(
+              new DOMException(`The operation was aborted.`, `AbortError`),
+            );
+          });
         });
-      });
 
-    const timeoutBlnk = new Blnk(
-      apiKey,
-      {...options, timeout: 10, retryCount: 3, retryDelayMs: 1},
-      mockServices,
-      FormatResponse,
-      timeoutFetch,
-    );
+      const timeoutBlnk = new Blnk(
+        apiKey,
+        {...options, timeout: 10, retryCount: 3, retryDelayMs: 1},
+        mockServices,
+        FormatResponse,
+        timeoutFetch,
+      );
 
-    const result = await timeoutBlnk[`request`](`/slow`, {}, `GET`);
+      const result = await timeoutBlnk[`request`](`/slow`, {}, `GET`);
 
-    tt.equal(calls, 1);
-    tt.equal(result.status, 408);
-    tt.end();
-  });
+      tt.equal(calls, 1);
+      tt.equal(result.status, 408);
+      tt.end();
+    },
+  );
 
   t.test(
     `request returns structured error after GET retries are exhausted`,


### PR DESCRIPTION
## Summary
- Skip JSON parsing for successful `204` / `205` responses in `baseBlnkClient.request()`
- Return `{ status, message: "Success", data: null }` instead of surfacing `500 Unexpected end of JSON input`

Fixes the bug Praise reported where `ApiKeys.delete` succeeded on Core but failed in the SDK.

## Acceptance criteria
- [x] `request()` skips JSON parsing for successful `204` responses (also `205`)
- [x] Successful no-content responses return `{ status, message: "Success", data: null }`
- [x] Integration-style unit test in `baseBlnkClient.test.ts` mocks empty `204` fetch and asserts success (not `500`)
- [x] `ApiKeys.delete` test through mocked `204` fetch confirms `status: 204` and `data: null`
- [x] README note for `ApiKeys.delete` remains accurate

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` — 897 passing