### PR TITLE
Add Identity.getTokenizedFields (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,14 @@ console.log('Identity Created:', newIdentity);
 
 | Method | Endpoint | Use case |
 |--------|----------|----------|
+| `Identity.getTokenizedFields(id)` | `GET /identities/{identity_id}/tokenized-fields` | List fields currently tokenized on an identity |
 | `Identity.tokenize(id, data)` | `POST /identities/{identity_id}/tokenize` | Tokenize multiple PII fields on an identity |
 
 ```typescript
 const { Identity } = blnk;
+
+const tokenizedFields = await Identity.getTokenizedFields(identity.data!.identity_id);
+// tokenizedFields.data?.tokenized_fields — e.g. ["FirstName", "EmailAddress"]
 
 // Use PascalCase struct field names — not the snake_case JSON keys on IdentityData.
 const tokenized = await Identity.tokenize(identity.data!.identity_id, {
@@ -188,7 +192,7 @@ const tokenized = await Identity.tokenize(identity.data!.identity_id, {
 
 > `fields` must be Core struct names (`FirstName`, `EmailAddress`, …). Passing `first_name` or `email_address` from `IdentityData` will be rejected.
 
-See the [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
+See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields) and [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
 
 ---
 

--- a/src/blnk/endpoints/identity.ts
+++ b/src/blnk/endpoints/identity.ts
@@ -3,6 +3,7 @@ import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {
   IdentityData,
   IdentityDataResponse,
+  GetTokenizedFieldsResp,
   TokenizeIdentityData,
   TokenizeIdentityResp,
 } from "../../types/identity";
@@ -10,6 +11,7 @@ import {HandleError} from "../utils/logger";
 import {serializeIdentityData} from "../utils/identitySerialization";
 import {
   ValidateIdentity,
+  ValidateIdentityId,
   ValidateTokenizeIdentityData,
 } from "../utils/validators/identityValidators";
 
@@ -187,6 +189,35 @@ export class Identity {
         this.logger,
         this.formatResponse,
         this.update.name,
+      );
+    }
+  }
+
+  /**
+   * Returns the list of fields currently tokenized on an identity.
+   *
+   * @see https://docs.blnkfinance.com/reference/get-tokenized-fields
+   */
+  async getTokenizedFields(id: string) {
+    try {
+      const validatorResponse = ValidateIdentityId(id);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<null, GetTokenizedFieldsResp>(
+        `identities/${id}/tokenized-fields`,
+        null,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.getTokenizedFields.name,
       );
     }
   }

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -40,12 +40,21 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
   return null;
 }
 
+export function ValidateIdentityId(id: string): string | null {
+  if (!IsValidString(id) || id === ``) {
+    return `identity id is required`;
+  }
+
+  return null;
+}
+
 export function ValidateTokenizeIdentityData(
   id: string,
   data: TokenizeIdentityData,
 ): string | null {
-  if (!IsValidString(id) || id === ``) {
-    return `identity id is required`;
+  const idError = ValidateIdentityId(id);
+  if (idError) {
+    return idError;
   }
 
   if (!data || typeof data !== `object`) {

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -56,3 +56,7 @@ export interface TokenizeIdentityData {
 export interface TokenizeIdentityResp {
   message: string;
 }
+
+export interface GetTokenizedFieldsResp {
+  tokenized_fields: TokenizableIdentityField[];
+}

--- a/tests/unit/blnk/endpoints/identityGetTokenizedFields.test.ts
+++ b/tests/unit/blnk/endpoints/identityGetTokenizedFields.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Identity} from "../../../../src/blnk/endpoints/identity";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {GetTokenizedFieldsResp} from "../../../../src/types/identity";
+
+const mockResponse: GetTokenizedFieldsResp = {
+  tokenized_fields: [`FirstName`, `LastName`, `EmailAddress`, `PhoneNumber`],
+};
+
+tap.test(`Issue #24 — Identity.getTokenizedFields`, async t => {
+  t.test(`getTokenizedFields GETs identities/{id}/tokenized-fields`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.getTokenizedFields(`idt_test_123`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenized-fields`, null, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.same(response.data?.tokenized_fields, mockResponse.tokenized_fields);
+    tt.end();
+  });
+
+  t.test(`getTokenizedFields returns empty list for fresh identity`, async tt => {
+    const mockLogger = createMockLogger();
+    const emptyResponse: GetTokenizedFieldsResp = {tokenized_fields: []};
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: emptyResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.getTokenizedFields(`idt_test_123`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenized-fields`, null, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.same(response.data?.tokenized_fields, []);
+    tt.end();
+  });
+
+  t.test(`getTokenizedFields rejects empty identity id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.getTokenizedFields(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `identity id is required`);
+    tt.end();
+  });
+
+  t.test(`getTokenizedFields forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Identity not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.getTokenizedFields(`idt_missing`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_missing/tokenized-fields`, null, `GET`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/identityIdValidators.test.ts
+++ b/tests/unit/blnk/utils/identityIdValidators.test.ts
@@ -1,0 +1,9 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateIdentityId} from "../../../../src/blnk/utils/validators/identityValidators";
+
+tap.test(`ValidateIdentityId`, async t => {
+  t.equal(ValidateIdentityId(`idt_test_123`), null);
+  t.equal(ValidateIdentityId(``), `identity id is required`);
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `Identity.getTokenizedFields(id)` calling `GET /identities/{identity_id}/tokenized-fields`
- Add `GetTokenizedFieldsResp` type with `tokenized_fields: TokenizableIdentityField[]`
- Extract shared `ValidateIdentityId` validator (reused by tokenize validation)
- Unit tests for success, empty list, client validation, and API error forwarding
- README endpoint map + usage example

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (911 passing)
- [ ] Manual: create identity → tokenize fields → `getTokenizedFields` returns PascalCase field names

Closes #24