### PR TITLE
Add Identity.tokenizeField (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ console.log('Identity Created:', newIdentity);
 | Method | Endpoint | Use case |
 |--------|----------|----------|
 | `Identity.getTokenizedFields(id)` | `GET /identities/{identity_id}/tokenized-fields` | List fields currently tokenized on an identity |
+| `Identity.tokenizeField(id, field)` | `POST /identities/{identity_id}/tokenize/{field}` | Tokenize one PII field on an identity |
 | `Identity.tokenize(id, data)` | `POST /identities/{identity_id}/tokenize` | Tokenize multiple PII fields on an identity |
 
 ```typescript
@@ -183,6 +184,10 @@ const { Identity } = blnk;
 const tokenizedFields = await Identity.getTokenizedFields(identity.data!.identity_id);
 // tokenizedFields.data?.tokenized_fields — e.g. ["FirstName", "EmailAddress"]
 
+// Tokenize a single field (PascalCase struct name in the path).
+const oneField = await Identity.tokenizeField(identity.data!.identity_id, 'EmailAddress');
+// oneField.data?.message — "Field tokenized successfully"
+
 // Use PascalCase struct field names — not the snake_case JSON keys on IdentityData.
 const tokenized = await Identity.tokenize(identity.data!.identity_id, {
   fields: ['FirstName', 'LastName', 'EmailAddress', 'PhoneNumber'],
@@ -190,9 +195,9 @@ const tokenized = await Identity.tokenize(identity.data!.identity_id, {
 // tokenized.data?.message — "Fields tokenized successfully"
 ```
 
-> `fields` must be Core struct names (`FirstName`, `EmailAddress`, …). Passing `first_name` or `email_address` from `IdentityData` will be rejected.
+> Field names must be Core struct names (`FirstName`, `EmailAddress`, …). Passing `first_name` or `email_address` from `IdentityData` will be rejected.
 
-See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields) and [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
+See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields), [Tokenize field reference](https://docs.blnkfinance.com/reference/tokenize-field), and [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
 
 ---
 

--- a/src/blnk/endpoints/identity.ts
+++ b/src/blnk/endpoints/identity.ts
@@ -4,7 +4,9 @@ import {
   IdentityData,
   IdentityDataResponse,
   GetTokenizedFieldsResp,
+  TokenizableIdentityField,
   TokenizeIdentityData,
+  TokenizeIdentityFieldResp,
   TokenizeIdentityResp,
 } from "../../types/identity";
 import {HandleError} from "../utils/logger";
@@ -13,6 +15,7 @@ import {
   ValidateIdentity,
   ValidateIdentityId,
   ValidateTokenizeIdentityData,
+  ValidateTokenizeIdentityField,
 } from "../utils/validators/identityValidators";
 
 /**
@@ -218,6 +221,35 @@ export class Identity {
         this.logger,
         this.formatResponse,
         this.getTokenizedFields.name,
+      );
+    }
+  }
+
+  /**
+   * Tokenizes a single PII field on an identity.
+   *
+   * @see https://docs.blnkfinance.com/reference/tokenize-field
+   */
+  async tokenizeField(id: string, field: TokenizableIdentityField) {
+    try {
+      const validatorResponse = ValidateTokenizeIdentityField(id, field);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<null, TokenizeIdentityFieldResp>(
+        `identities/${id}/tokenize/${field}`,
+        null,
+        `POST`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.tokenizeField.name,
       );
     }
   }

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -1,4 +1,8 @@
-import {IdentityData, TokenizeIdentityData} from "../../../types/identity";
+import {
+  IdentityData,
+  TokenizableIdentityField,
+  TokenizeIdentityData,
+} from "../../../types/identity";
 import {isValidMetaData} from "./ledgerBalance";
 import {isValidIdentityDateInput} from "../identitySerialization";
 import {IsValidArray, IsValidString} from "../stringUtils";
@@ -43,6 +47,22 @@ export function ValidateIdentity<T extends Record<string, unknown>>(
 export function ValidateIdentityId(id: string): string | null {
   if (!IsValidString(id) || id === ``) {
     return `identity id is required`;
+  }
+
+  return null;
+}
+
+export function ValidateTokenizeIdentityField(
+  id: string,
+  field: TokenizableIdentityField,
+): string | null {
+  const idError = ValidateIdentityId(id);
+  if (idError) {
+    return idError;
+  }
+
+  if (!IsValidString(field) || String(field).length === 0) {
+    return `field name is required`;
   }
 
   return null;

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -57,6 +57,10 @@ export interface TokenizeIdentityResp {
   message: string;
 }
 
+export interface TokenizeIdentityFieldResp {
+  message: string;
+}
+
 export interface GetTokenizedFieldsResp {
   tokenized_fields: TokenizableIdentityField[];
 }

--- a/tests/unit/blnk/endpoints/identityTokenizeField.test.ts
+++ b/tests/unit/blnk/endpoints/identityTokenizeField.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Identity} from "../../../../src/blnk/endpoints/identity";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {TokenizeIdentityFieldResp} from "../../../../src/types/identity";
+
+const mockResponse: TokenizeIdentityFieldResp = {
+  message: `Field tokenized successfully`,
+};
+
+tap.test(`Issue #22 — Identity.tokenizeField`, async t => {
+  t.test(`tokenizeField POSTs identities/{id}/tokenize/{field}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenizeField(`idt_test_123`, `FirstName`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenize/FirstName`, null, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.message, `Field tokenized successfully`);
+    tt.end();
+  });
+
+  t.test(`tokenizeField uses PascalCase struct field name in path`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    await identity.tokenizeField(`idt_test_123`, `EmailAddress`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenize/EmailAddress`, null, `POST`],
+    ]);
+    tt.end();
+  });
+
+  t.test(`tokenizeField rejects empty identity id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenizeField(``, `FirstName`);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `identity id is required`);
+    tt.end();
+  });
+
+  t.test(`tokenizeField rejects empty field name`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenizeField(
+      `idt_test_123`,
+      `` as `FirstName`,
+    );
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `field name is required`);
+    tt.end();
+  });
+
+  t.test(`tokenizeField forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 409,
+      message: `Field already tokenized`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.tokenizeField(`idt_test_123`, `FirstName`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/tokenize/FirstName`, null, `POST`],
+    ]);
+    tt.equal(response.status, 409);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/identityTokenizeFieldValidators.test.ts
+++ b/tests/unit/blnk/utils/identityTokenizeFieldValidators.test.ts
@@ -1,0 +1,16 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateTokenizeIdentityField} from "../../../../src/blnk/utils/validators/identityValidators";
+
+tap.test(`ValidateTokenizeIdentityField`, async t => {
+  t.equal(ValidateTokenizeIdentityField(`idt_test_123`, `FirstName`), null);
+  t.equal(
+    ValidateTokenizeIdentityField(``, `FirstName`),
+    `identity id is required`,
+  );
+  t.equal(
+    ValidateTokenizeIdentityField(`idt_test_123`, `` as `FirstName`),
+    `field name is required`,
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `Identity.tokenizeField(id, field)` calling `POST /identities/{identity_id}/tokenize/{field}`
- Add `TokenizeIdentityFieldResp` type (`message: "Field tokenized successfully"`)
- Add `ValidateTokenizeIdentityField` (non-empty identity id + field name)
- Unit tests for endpoint path, PascalCase field in URL, validation, and API error forwarding
- README endpoint map + usage example

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (927 passing)
- [ ] Postman: add **TS SDK (#22)** folder to `Blnk SDK Issues — Local Core Tests` (Postman MCP auth unavailable in agent session)
  - `POST {{baseUrl}}/identities/{{identity_id}}/tokenize/EmailAddress` → 200, `"Field tokenized successfully"`
  - Re-run same request → 409 already tokenized

Closes #22