### PR TITLE
Add Identity.detokenize (closes #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ console.log('Identity Created:', newIdentity);
 | `Identity.getTokenizedFields(id)` | `GET /identities/{identity_id}/tokenized-fields` | List fields currently tokenized on an identity |
 | `Identity.tokenizeField(id, field)` | `POST /identities/{identity_id}/tokenize/{field}` | Tokenize one PII field on an identity |
 | `Identity.tokenize(id, data)` | `POST /identities/{identity_id}/tokenize` | Tokenize multiple PII fields on an identity |
+| `Identity.detokenize(id, data)` | `POST /identities/{identity_id}/detokenize` | Detokenize fields and return original values |
 
 ```typescript
 const { Identity } = blnk;
@@ -193,11 +194,17 @@ const tokenized = await Identity.tokenize(identity.data!.identity_id, {
   fields: ['FirstName', 'LastName', 'EmailAddress', 'PhoneNumber'],
 });
 // tokenized.data?.message — "Fields tokenized successfully"
+
+// Detokenize specific fields, or pass { fields: [] } to detokenize all tokenized fields.
+const restored = await Identity.detokenize(identity.data!.identity_id, {
+  fields: ['FirstName', 'EmailAddress'],
+});
+// restored.data?.fields — e.g. { FirstName: "Jane", EmailAddress: "jane@example.com" }
 ```
 
 > Field names must be Core struct names (`FirstName`, `EmailAddress`, …). Passing `first_name` or `email_address` from `IdentityData` will be rejected.
 
-See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields), [Tokenize field reference](https://docs.blnkfinance.com/reference/tokenize-field), and [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity).
+See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields), [Tokenize field reference](https://docs.blnkfinance.com/reference/tokenize-field), [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity), and [Detokenize identity reference](https://docs.blnkfinance.com/reference/detokenize-identity).
 
 ---
 

--- a/src/blnk/endpoints/identity.ts
+++ b/src/blnk/endpoints/identity.ts
@@ -4,6 +4,8 @@ import {
   IdentityData,
   IdentityDataResponse,
   GetTokenizedFieldsResp,
+  DetokenizeIdentityData,
+  DetokenizeIdentityResp,
   TokenizableIdentityField,
   TokenizeIdentityData,
   TokenizeIdentityFieldResp,
@@ -12,6 +14,7 @@ import {
 import {HandleError} from "../utils/logger";
 import {serializeIdentityData} from "../utils/identitySerialization";
 import {
+  ValidateDetokenizeIdentityData,
   ValidateIdentity,
   ValidateIdentityId,
   ValidateTokenizeIdentityData,
@@ -278,6 +281,36 @@ export class Identity {
         this.logger,
         this.formatResponse,
         this.tokenize.name,
+      );
+    }
+  }
+
+  /**
+   * Detokenizes multiple PII fields on an identity and returns the original values.
+   *
+   * Pass an empty `fields` array to detokenize all currently tokenized fields.
+   *
+   * @see https://docs.blnkfinance.com/reference/detokenize-identity
+   */
+  async detokenize(id: string, data: DetokenizeIdentityData) {
+    try {
+      const validatorResponse = ValidateDetokenizeIdentityData(id, data);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<
+        DetokenizeIdentityData,
+        DetokenizeIdentityResp
+      >(`identities/${id}/detokenize`, data, `POST`);
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.detokenize.name,
       );
     }
   }

--- a/src/blnk/utils/validators/identityValidators.ts
+++ b/src/blnk/utils/validators/identityValidators.ts
@@ -1,4 +1,5 @@
 import {
+  DetokenizeIdentityData,
   IdentityData,
   TokenizableIdentityField,
   TokenizeIdentityData,
@@ -63,6 +64,32 @@ export function ValidateTokenizeIdentityField(
 
   if (!IsValidString(field) || String(field).length === 0) {
     return `field name is required`;
+  }
+
+  return null;
+}
+
+export function ValidateDetokenizeIdentityData(
+  id: string,
+  data: DetokenizeIdentityData,
+): string | null {
+  const idError = ValidateIdentityId(id);
+  if (idError) {
+    return idError;
+  }
+
+  if (!data || typeof data !== `object`) {
+    return `Data must be a valid object of type DetokenizeIdentityData`;
+  }
+
+  if (!IsValidArray(data.fields)) {
+    return `fields must be an array`;
+  }
+
+  for (const field of data.fields) {
+    if (!IsValidString(field) || String(field).length === 0) {
+      return `each field must be a non-empty string`;
+    }
   }
 
   return null;

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -64,3 +64,17 @@ export interface TokenizeIdentityFieldResp {
 export interface GetTokenizedFieldsResp {
   tokenized_fields: TokenizableIdentityField[];
 }
+
+export interface DetokenizeIdentityData {
+  /**
+   * Field names to detokenize. Use PascalCase struct names (`FirstName`,
+   * `EmailAddress`), not the snake_case keys on `IdentityData`. Pass an empty
+   * array to detokenize all currently tokenized fields.
+   */
+  fields: TokenizableIdentityField[];
+}
+
+export interface DetokenizeIdentityResp {
+  /** Original field values keyed by field name as returned by Core. */
+  fields: Record<string, string>;
+}

--- a/tests/unit/blnk/endpoints/identityDetokenize.test.ts
+++ b/tests/unit/blnk/endpoints/identityDetokenize.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Identity} from "../../../../src/blnk/endpoints/identity";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {
+  DetokenizeIdentityData,
+  DetokenizeIdentityResp,
+} from "../../../../src/types/identity";
+
+const validData: DetokenizeIdentityData = {
+  fields: [`FirstName`, `EmailAddress`],
+};
+
+const mockResponse: DetokenizeIdentityResp = {
+  fields: {
+    FirstName: `Jane`,
+    EmailAddress: `jane@example.com`,
+  },
+};
+
+tap.test(`Issue #26 — Identity.detokenize`, async t => {
+  t.test(`detokenize POSTs identities/{id}/detokenize`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenize(`idt_test_123`, validData);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/detokenize`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.fields.FirstName, `Jane`);
+    tt.equal(response.data?.fields.EmailAddress, `jane@example.com`);
+    tt.end();
+  });
+
+  t.test(`detokenize allows empty fields to detokenize all`, async tt => {
+    const mockLogger = createMockLogger();
+    const emptyFieldsData: DetokenizeIdentityData = {fields: []};
+    const allFieldsResponse: DetokenizeIdentityResp = {
+      fields: {
+        FirstName: `Jane`,
+        EmailAddress: `jane@example.com`,
+        PhoneNumber: `+1234567890`,
+      },
+    };
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: allFieldsResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenize(`idt_test_123`, emptyFieldsData);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/detokenize`, emptyFieldsData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(Object.keys(response.data?.fields ?? {}).length, 3);
+    tt.end();
+  });
+
+  t.test(`detokenize rejects empty identity id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenize(``, validData);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `identity id is required`);
+    tt.end();
+  });
+
+  t.test(`detokenize rejects blank field names`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenize(`idt_test_123`, {
+      fields: [`FirstName`, `` as `FirstName`],
+    });
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `each field must be a non-empty string`);
+    tt.end();
+  });
+
+  t.test(`detokenize forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 400,
+      message: `Field is not tokenized`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenize(`idt_test_123`, {
+      fields: [`Street`],
+    });
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/detokenize`, {fields: [`Street`]}, `POST`],
+    ]);
+    tt.equal(response.status, 400);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/identityDetokenizeValidators.test.ts
+++ b/tests/unit/blnk/utils/identityDetokenizeValidators.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateDetokenizeIdentityData} from "../../../../src/blnk/utils/validators/identityValidators";
+import {DetokenizeIdentityData} from "../../../../src/types/identity";
+
+tap.test(`ValidateDetokenizeIdentityData`, async t => {
+  const validData: DetokenizeIdentityData = {
+    fields: [`FirstName`, `EmailAddress`],
+  };
+
+  t.equal(ValidateDetokenizeIdentityData(`idt_test_123`, validData), null);
+  t.equal(
+    ValidateDetokenizeIdentityData(`idt_test_123`, {fields: []}),
+    null,
+  );
+  t.equal(
+    ValidateDetokenizeIdentityData(``, validData),
+    `identity id is required`,
+  );
+  t.equal(
+    ValidateDetokenizeIdentityData(`idt_test_123`, {
+      fields: [`FirstName`, `` as `FirstName`],
+    }),
+    `each field must be a non-empty string`,
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Add `Identity.detokenize(id, data)` calling `POST /identities/{identity_id}/detokenize`
- Add `DetokenizeIdentityData` / `DetokenizeIdentityResp` types (`fields` map of original values)
- Add `ValidateDetokenizeIdentityData` — empty `fields` array allowed (detokenizes all tokenized fields per Core)
- Unit tests for explicit fields, empty-array detokenize-all, validation, and API error forwarding
- README endpoint map + usage example

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (947 passing)
- [ ] Manual: tokenize fields → `detokenize({ fields: ['FirstName'] })` returns original values
- [ ] Manual: `detokenize({ fields: [] })` returns all tokenized field values

Closes #26