### PR TITLE
Add Identity.detokenizeField (closes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ console.log('Identity Created:', newIdentity);
 | `Identity.tokenizeField(id, field)` | `POST /identities/{identity_id}/tokenize/{field}` | Tokenize one PII field on an identity |
 | `Identity.tokenize(id, data)` | `POST /identities/{identity_id}/tokenize` | Tokenize multiple PII fields on an identity |
 | `Identity.detokenize(id, data)` | `POST /identities/{identity_id}/detokenize` | Detokenize fields and return original values |
+| `Identity.detokenizeField(id, field)` | `GET /identities/{identity_id}/detokenize/{field}` | Detokenize one field and return its original value |
 
 ```typescript
 const { Identity } = blnk;
@@ -200,11 +201,15 @@ const restored = await Identity.detokenize(identity.data!.identity_id, {
   fields: ['FirstName', 'EmailAddress'],
 });
 // restored.data?.fields — e.g. { FirstName: "Jane", EmailAddress: "jane@example.com" }
+
+// Detokenize a single field and read the original value.
+const email = await Identity.detokenizeField(identity.data!.identity_id, 'EmailAddress');
+// email.data?.value — e.g. "jane@example.com"
 ```
 
 > Field names must be Core struct names (`FirstName`, `EmailAddress`, …). Passing `first_name` or `email_address` from `IdentityData` will be rejected.
 
-See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields), [Tokenize field reference](https://docs.blnkfinance.com/reference/tokenize-field), [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity), and [Detokenize identity reference](https://docs.blnkfinance.com/reference/detokenize-identity).
+See the [Get tokenized fields reference](https://docs.blnkfinance.com/reference/get-tokenized-fields), [Tokenize field reference](https://docs.blnkfinance.com/reference/tokenize-field), [Tokenize identity reference](https://docs.blnkfinance.com/reference/tokenize-identity), [Detokenize field reference](https://docs.blnkfinance.com/reference/detokenize-field), and [Detokenize identity reference](https://docs.blnkfinance.com/reference/detokenize-identity).
 
 ---
 

--- a/src/blnk/endpoints/identity.ts
+++ b/src/blnk/endpoints/identity.ts
@@ -5,6 +5,7 @@ import {
   IdentityDataResponse,
   GetTokenizedFieldsResp,
   DetokenizeIdentityData,
+  DetokenizeIdentityFieldResp,
   DetokenizeIdentityResp,
   TokenizableIdentityField,
   TokenizeIdentityData,
@@ -281,6 +282,35 @@ export class Identity {
         this.logger,
         this.formatResponse,
         this.tokenize.name,
+      );
+    }
+  }
+
+  /**
+   * Detokenizes a single PII field on an identity and returns the original value.
+   *
+   * @see https://docs.blnkfinance.com/reference/detokenize-field
+   */
+  async detokenizeField(id: string, field: TokenizableIdentityField) {
+    try {
+      const validatorResponse = ValidateTokenizeIdentityField(id, field);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<null, DetokenizeIdentityFieldResp>(
+        `identities/${id}/detokenize/${field}`,
+        null,
+        `GET`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.detokenizeField.name,
       );
     }
   }

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -78,3 +78,9 @@ export interface DetokenizeIdentityResp {
   /** Original field values keyed by field name as returned by Core. */
   fields: Record<string, string>;
 }
+
+export interface DetokenizeIdentityFieldResp {
+  /** Field name as returned by Core (echoes the path parameter). */
+  field: string;
+  value: string;
+}

--- a/tests/unit/blnk/endpoints/identityDetokenizeField.test.ts
+++ b/tests/unit/blnk/endpoints/identityDetokenizeField.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Identity} from "../../../../src/blnk/endpoints/identity";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {DetokenizeIdentityFieldResp} from "../../../../src/types/identity";
+
+const mockResponse: DetokenizeIdentityFieldResp = {
+  field: `EmailAddress`,
+  value: `jane@example.com`,
+};
+
+tap.test(`Issue #25 — Identity.detokenizeField`, async t => {
+  t.test(`detokenizeField GETs identities/{id}/detokenize/{field}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenizeField(
+      `idt_test_123`,
+      `EmailAddress`,
+    );
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/detokenize/EmailAddress`, null, `GET`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.field, `EmailAddress`);
+    tt.equal(response.data?.value, `jane@example.com`);
+    tt.end();
+  });
+
+  t.test(`detokenizeField uses PascalCase struct field name in path`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: {field: `FirstName`, value: `Jane`} as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    await identity.detokenizeField(`idt_test_123`, `FirstName`);
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/detokenize/FirstName`, null, `GET`],
+    ]);
+    tt.end();
+  });
+
+  t.test(`detokenizeField rejects empty identity id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenizeField(``, `EmailAddress`);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `identity id is required`);
+    tt.end();
+  });
+
+  t.test(`detokenizeField rejects empty field name`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: mockResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenizeField(
+      `idt_test_123`,
+      `` as `EmailAddress`,
+    );
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `field name is required`);
+    tt.end();
+  });
+
+  t.test(`detokenizeField forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 400,
+      message: `Field is not tokenized`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+
+    const response = await identity.detokenizeField(
+      `idt_test_123`,
+      `PhoneNumber`,
+    );
+
+    tt.match(capturedRequest.args(), [
+      [`identities/idt_test_123/detokenize/PhoneNumber`, null, `GET`],
+    ]);
+    tt.equal(response.status, 400);
+    tt.end();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Identity.detokenizeField(id, field)` calling `GET /identities/{identity_id}/detokenize/{field}`
- Add `DetokenizeIdentityFieldResp` type (`field`, `value`) matching the Core reference
- Reuses `ValidateTokenizeIdentityField` for identity id + field name validation
- Unit tests for GET path, PascalCase field in URL, validation, and API error forwarding
- README endpoint map + usage example

Completes the identity tokenization SDK parity batch (#24, #22, #26, #25).

## Test plan
- [x] `npm run compile`
- [x] `npm run test:unit` (961 passing)
- [ ] Manual: tokenize `EmailAddress` → `detokenizeField(id, 'EmailAddress')` returns `{ field, value }`

Closes #25