### PR TITLE
feat(balance-monitor): add delete for Core 0.15.0 (closes #120)

### DIFF
--- a/CORE-0.15.0-GAP-CHECKLIST.md
+++ b/CORE-0.15.0-GAP-CHECKLIST.md
@@ -31,7 +31,7 @@
 | # | Core route | SDK method | Status | Suggested issue title |
 |---|------------|------------|--------|------------------------|
 | A1 | `DELETE /identities/{id}` | `Identity.delete(id)` | 🚧 In progress | [#116](https://github.com/blnkfinance/blnk-ts/issues/116) |
-| A2 | `DELETE /balance-monitors/{id}` | `BalanceMonitor.delete(id)` | ❌ Missing | [#120](https://github.com/blnkfinance/blnk-ts/issues/120) |
+| A2 | `DELETE /balance-monitors/{id}` | `BalanceMonitor.delete(id)` | 🚧 In progress | [#120](https://github.com/blnkfinance/blnk-ts/issues/120) |
 
 **Acceptance criteria (both):**
 - Method calls correct endpoint with `DELETE`

--- a/README.md
+++ b/README.md
@@ -341,6 +341,21 @@ const response = await LedgerBalances.getLineage(
 // response.data.providers
 ```
 
+### Delete balance monitor
+
+| Method | Endpoint | Use case |
+|--------|----------|----------|
+| `BalanceMonitor.delete(id)` | `DELETE /balance-monitors/{monitor_id}` | Remove a balance monitor (Core 0.15.0+) |
+
+```typescript
+const { BalanceMonitor } = blnk;
+
+const deleted = await BalanceMonitor.delete(monitor.data!.monitor_id);
+// deleted.data?.message — "BalanceMonitor deleted successfully"
+```
+
+See the [Delete balance monitor reference](https://docs.blnkfinance.com/reference/delete-balance-monitor).
+
 ---
 
 ## 6. Recording Transactions

--- a/src/blnk/endpoints/balanceMonitors.ts
+++ b/src/blnk/endpoints/balanceMonitors.ts
@@ -1,8 +1,15 @@
-import {MonitorData, MonitorDataResp} from "../../types/balanceMonitor";
+import {
+  DeleteBalanceMonitorResp,
+  MonitorData,
+  MonitorDataResp,
+} from "../../types/balanceMonitor";
 import {BlnkLogger} from "../../types/blnkClient";
 import {BlnkRequest, FormatResponseType} from "../../types/general";
 import {HandleError} from "../utils/logger";
-import {ValidateMonitorData} from "../utils/validators/balanceMonitors";
+import {
+  ValidateMonitorData,
+  ValidateMonitorId,
+} from "../utils/validators/balanceMonitors";
 
 /**
  * Represents a Balance Monitor that interacts with the balance monitoring system.
@@ -16,6 +23,7 @@ import {ValidateMonitorData} from "../utils/validators/balanceMonitors";
  * @method get - Retrieves a balance monitor by its ID.
  * @method list - Retrieves a list of all balance monitors.
  * @method update - Updates an existing balance monitor with new data.
+ * @method delete - Deletes a balance monitor by its ID.
  * @example
  * const monitor = new BalanceMonitor(requestFunction, loggerInstance, formatResponseFunction);
  * const newMonitorData = { balance_id: '123', condition: { ... } };
@@ -172,6 +180,35 @@ export class BalanceMonitor {
         this.logger,
         this.formatResponse,
         this.update.name,
+      );
+    }
+  }
+
+  /**
+   * Deletes a balance monitor by ID.
+   *
+   * @see https://docs.blnkfinance.com/reference/delete-balance-monitor
+   */
+  async delete(id: string) {
+    try {
+      const validatorResponse = ValidateMonitorId(id);
+      if (validatorResponse) {
+        return this.formatResponse(400, validatorResponse, null);
+      }
+
+      const response = await this.request<undefined, DeleteBalanceMonitorResp>(
+        `balance-monitors/${encodeURIComponent(id)}`,
+        undefined,
+        `DELETE`,
+      );
+
+      return response;
+    } catch (error: unknown) {
+      return HandleError(
+        error,
+        this.logger,
+        this.formatResponse,
+        this.delete.name,
       );
     }
   }

--- a/src/blnk/utils/validators/balanceMonitors.ts
+++ b/src/blnk/utils/validators/balanceMonitors.ts
@@ -1,6 +1,14 @@
 import {MonitorCondition, MonitorData} from "../../../types/balanceMonitor";
 import {IsValidNumber, IsValidOperator, IsValidString} from "../stringUtils";
 
+export function ValidateMonitorId(id: string): string | null {
+  if (!IsValidString(id) || id === ``) {
+    return `monitor id is required`;
+  }
+
+  return null;
+}
+
 export function ValidateMonitorData(data: MonitorData): string | null {
   // Validate if data is an object
   if (!data || typeof data !== `object`) {

--- a/src/types/balanceMonitor.ts
+++ b/src/types/balanceMonitor.ts
@@ -17,3 +17,7 @@ export interface MonitorDataResp extends MonitorData {
   monitor_id: string;
   created_at: string; // ISO date string
 }
+
+export interface DeleteBalanceMonitorResp {
+  message: string;
+}

--- a/tests/unit/blnk/endpoints/balanceMonitorDelete.test.ts
+++ b/tests/unit/blnk/endpoints/balanceMonitorDelete.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {BalanceMonitor} from "../../../../src/blnk/endpoints/balanceMonitors";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {DeleteBalanceMonitorResp} from "../../../../src/types/balanceMonitor";
+
+tap.test(`Issue #120 — BalanceMonitor.delete`, async t => {
+  const deleteResponse: DeleteBalanceMonitorResp = {
+    message: `BalanceMonitor deleted successfully`,
+  };
+
+  t.test(`delete DELETEs balance-monitors/{id}`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: deleteResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const balanceMonitor = new BalanceMonitor(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await balanceMonitor.delete(`mon_test_123`);
+
+    tt.match(capturedRequest.args(), [
+      [`balance-monitors/mon_test_123`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.message, `BalanceMonitor deleted successfully`);
+    tt.end();
+  });
+
+  t.test(`delete URL-encodes monitor id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: deleteResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const balanceMonitor = new BalanceMonitor(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    await balanceMonitor.delete(`mon_test/special`);
+
+    tt.match(capturedRequest.args(), [
+      [`balance-monitors/mon_test%2Fspecial`, undefined, `DELETE`],
+    ]);
+    tt.end();
+  });
+
+  t.test(`delete returns 400 for empty id`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 200,
+      message: `Success`,
+      data: deleteResponse as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const balanceMonitor = new BalanceMonitor(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await balanceMonitor.delete(``);
+
+    tt.equal(capturedRequest.calls.length, 0);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `monitor id is required`);
+    tt.end();
+  });
+
+  t.test(`delete forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 404,
+      message: `Balance monitor not found`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const balanceMonitor = new BalanceMonitor(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await balanceMonitor.delete(`mon_missing`);
+
+    tt.match(capturedRequest.args(), [
+      [`balance-monitors/mon_missing`, undefined, `DELETE`],
+    ]);
+    tt.equal(response.status, 404);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/utils/balanceMonitorIdValidators.test.ts
+++ b/tests/unit/blnk/utils/balanceMonitorIdValidators.test.ts
@@ -1,0 +1,9 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {ValidateMonitorId} from "../../../../src/blnk/utils/validators/balanceMonitors";
+
+tap.test(`ValidateMonitorId`, async t => {
+  t.equal(ValidateMonitorId(`mon_test_123`), null);
+  t.equal(ValidateMonitorId(``), `monitor id is required`);
+  t.end();
+});


### PR DESCRIPTION
## Summary

- Adds `BalanceMonitor.delete(id)` for `DELETE /balance-monitors/{id}` (Core 0.15.0+)
- Adds `DeleteBalanceMonitorResp` type and `ValidateMonitorId` client-side validation
- Unit tests for endpoint + validator; README example; gap checklist updated
- Postman folder **`TS SDK (#120)`** added to **Blnk SDK Issues — Local Core Tests (fixed)** (5 requests: ledger → balance → monitor → delete → GET 404)

## Test plan

- [x] `npm run test:unit` — 983 pass (including 5 new tests)
- [x] Live Core 0.15.0 via curl: create → delete (200, `"BalanceMonitor deleted successfully"`) → get (404, `BAL_MONITOR_NOT_FOUND`)
- [x] Live Core 0.15.0 via SDK (`BlnkInit`): delete returns 200; subsequent get returns 404
- [x] Postman: run folder **`TS SDK (#120)`** with **No environment** + **Keep variable values** (user verification)

## Self-review

**Parity with #116 / `Identity.delete`:** Same pattern — `encodeURIComponent(id)`, empty-id validation before network call, `{ message: string }` response type, 4 endpoint tests + validator test.

**Core alignment:** Matches `DeleteBalanceMonitor` in Core (`message: "BalanceMonitor deleted successfully"`, 404 uses `BAL_MONITOR_NOT_FOUND`).

**Scope:** Minimal diff; no changes to existing create/get/list/update behavior. Postman folder is self-contained (creates ledger + balance + monitor) so it does not depend on Setup.

**No issues found** — ready for review after Postman confirmation.

Closes #120