### PR TITLE
fix(reconciliation): align run() response with Core 0.15.0 (closes #121)

### DIFF
--- a/CORE-0.15.0-GAP-CHECKLIST.md
+++ b/CORE-0.15.0-GAP-CHECKLIST.md
@@ -49,7 +49,7 @@
 
 | # | Area | Current SDK | Core 0.15.0 | Fix |
 |---|------|-------------|-------------|-----|
-| B1 | `Reconciliation.run` | `RunReconResp extends Matcher` | Returns only `{ reconciliation_id }` | [#121](https://github.com/blnkfinance/blnk-ts/issues/121) |
+| B1 | `Reconciliation.run` | `RunReconResp extends Matcher` | Returns only `{ reconciliation_id }` | 🚧 In progress [#121](https://github.com/blnkfinance/blnk-ts/issues/121) |
 | B2 | Transaction responses | `CreateTransactionResponse.rate` required | `rate` removed from responses | Make `rate?` optional or remove from response type |
 | B3 | Balance responses | `LedgerBalanceResp.currency_multiplier` required | Field removed | Make optional or remove from response type |
 | B4 | Search hit types | `currency_multiplier?`, `rate?` on documents | Fields removed from responses | Remove or mark deprecated optional |

--- a/README.md
+++ b/README.md
@@ -877,6 +877,25 @@ const status = await Reconciliation.get('recon_3803ea0d-28b4-4c73-a36b-5a9eb7a3e
 
 See the [View reconciliation details reference](https://docs.blnkfinance.com/reference/get-reconciliations).
 
+### Start batch reconciliation
+
+`Reconciliation.run` starts reconciliation from a prior upload (`POST /reconciliation/start`). Core 0.15.0 returns only a reconciliation ID — poll `Reconciliation.get(id)` or listen for `reconciliation.completed` / `reconciliation.failed` webhooks for results.
+
+```typescript
+const { Reconciliation } = blnk;
+
+const started = await Reconciliation.run({
+  upload_id: upload.data!.upload_id,
+  strategy: 'one_to_one',
+  dry_run: true,
+  grouping_criteria: 'amount',
+  matching_rule_ids: [rule.data!.rule_id],
+});
+// started.data?.reconciliation_id — use with Reconciliation.get() or webhooks
+```
+
+See the [Start reconciliation reference](https://docs.blnkfinance.com/reference/start-reconciliation).
+
 ### Instant reconciliation
 
 ```typescript

--- a/src/blnk/endpoints/reconciliation.ts
+++ b/src/blnk/endpoints/reconciliation.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import {
   DeleteMatchingRuleResp,
   Matcher,
+  MatchingRuleResp,
   ReconciliationResp,
   ReconciliationUploadResp,
   RunInstantReconData,
@@ -30,7 +31,7 @@ import FormData1 from "form-data";
  * @returns {Promise<ApiResponse<ReconciliationUploadResp | null>>} - The API response after uploading.
  * @method createMatchingRule - Creates a matching rule for reconciliation.
  * @param {Matcher} data - Data containing the matching rule details.
- * @returns {Promise<ApiResponse<RunReconResp | null>>} - The API response after creating the matching rule.
+ * @returns {Promise<ApiResponse<MatchingRuleResp | null>>} - The API response after creating the matching rule.
  * @method run - Initiates a reconciliation run.
  * @param {RunReconData} data - Data required to start the reconciliation run.
  * @returns {Promise<ApiResponse<RunReconResp | null>>} - The API response after starting the reconciliation run.
@@ -137,7 +138,7 @@ export class Reconciliation {
       if (validatorResponse) {
         return this.formatResponse(400, validatorResponse, null);
       }
-      const response = await this.request<Matcher, RunReconResp>(
+      const response = await this.request<Matcher, MatchingRuleResp>(
         `reconciliation/matching-rules`,
         data,
         `POST`,
@@ -169,7 +170,7 @@ export class Reconciliation {
         return this.formatResponse(400, validatorResponse, null);
       }
 
-      const response = await this.request<Matcher, RunReconResp>(
+      const response = await this.request<Matcher, MatchingRuleResp>(
         `reconciliation/matching-rules/${ruleId}`,
         data,
         `PUT`,

--- a/src/types/reconciliation.ts
+++ b/src/types/reconciliation.ts
@@ -35,7 +35,12 @@ export interface RunReconData {
   matching_rule_ids: string[];
 }
 
-export interface RunReconResp extends Matcher {
+/** Response from `POST /reconciliation/start`. */
+export interface RunReconResp {
+  reconciliation_id: string;
+}
+
+export interface MatchingRuleResp extends Matcher {
   rule_id: string;
   created_at: string;
   updated_at: string;

--- a/tests/unit/blnk/endpoints/reconciliation.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliation.test.ts
@@ -112,7 +112,7 @@ tap.test(`Run Reconciliation`, async t => {
     const thirdPartyRequest: BlnkRequest = createMockBlnkRequest(
       true,
       undefined,
-      201,
+      200,
     );
     const capturedRequest = childTest.captureFn(thirdPartyRequest);
     const reconciliation = new Reconciliation(
@@ -131,7 +131,7 @@ tap.test(`Run Reconciliation`, async t => {
     childTest.match(capturedRequest.args(), [
       [`reconciliation/start`, data, `POST`],
     ]);
-    childTest.match(response.status, 201);
+    childTest.match(response.status, 200);
     childTest.end();
   });
 

--- a/tests/unit/blnk/endpoints/reconciliationRun.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliationRun.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
+import {createMockLogger} from "../../../mocks/blnkClientMocks";
+import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
+import {RunReconData} from "../../../../src/types/reconciliation";
+
+const validData: RunReconData = {
+  upload_id: `upload_test_123`,
+  matching_rule_ids: [`rule_test_123`],
+  dry_run: true,
+  strategy: `one_to_one`,
+  grouping_criteria: `amount`,
+};
+
+tap.test(`Issue #121 — Reconciliation.run`, async t => {
+  t.test(`run POSTs reconciliation/start`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <T, R>(
+      endpoint: string,
+      data: T,
+      method: `POST` | `GET` | `PUT` | `DELETE`,
+    ) => ({
+      status: 200,
+      message: `Success`,
+      data: {reconciliation_id: `recon_test_123`} as unknown as R,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.run(validData);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/start`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 200);
+    tt.equal(response.data?.reconciliation_id, `recon_test_123`);
+    tt.equal(Object.keys(response.data ?? {}).length, 1);
+    tt.end();
+  });
+
+  t.test(`run forwards API errors`, async tt => {
+    const mockLogger = createMockLogger();
+    const thirdPartyRequest = async <R>() => ({
+      status: 400,
+      message: `matching_rule_ids is required`,
+      data: null as R | null,
+    });
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const reconciliation = new Reconciliation(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+
+    const response = await reconciliation.run(validData);
+
+    tt.match(capturedRequest.args(), [
+      [`reconciliation/start`, validData, `POST`],
+    ]);
+    tt.equal(response.status, 400);
+    tt.end();
+  });
+});

--- a/tests/unit/blnk/endpoints/reconciliationUpdateMatchingRule.test.ts
+++ b/tests/unit/blnk/endpoints/reconciliationUpdateMatchingRule.test.ts
@@ -3,7 +3,7 @@ import tap from "tap";
 import {Reconciliation} from "../../../../src/blnk/endpoints/reconciliation";
 import {createMockLogger} from "../../../mocks/blnkClientMocks";
 import {FormatResponse} from "../../../../src/blnk/utils/httpClient";
-import {Matcher, RunReconResp} from "../../../../src/types/reconciliation";
+import {Matcher, MatchingRuleResp} from "../../../../src/types/reconciliation";
 
 const validData: Matcher = {
   name: `Updated matcher`,
@@ -14,7 +14,7 @@ const validData: Matcher = {
   ],
 };
 
-const mockResponse: RunReconResp = {
+const mockResponse: MatchingRuleResp = {
   ...validData,
   rule_id: `rule_test_123`,
   created_at: `2026-06-12T04:31:55.613241Z`,


### PR DESCRIPTION
## Summary

- `RunReconResp` is now `{ reconciliation_id: string }` (Core 0.15.0 `POST /reconciliation/start`)
- Introduces `MatchingRuleResp` for `createMatchingRule` / `updateMatchingRule` (full rule object with `rule_id`, timestamps, criteria)
- README documents batch start flow + webhook/poll guidance
- Unit tests for `run()` response shape; existing run test expects HTTP 200

## Test plan

- [x] `npm run test:unit` — 990 pass (2 new in `reconciliationRun.test.ts`)
- [x] Live Core 0.15.0 via curl: `POST /reconciliation/start` → 200, body `{ reconciliation_id }` only
- [x] Live Core 0.15.0 via SDK: `Reconciliation.run()` → `status: 200`, `data` keys `["reconciliation_id"]`

## Self-review

**Root cause:** `RunReconResp` incorrectly extended `Matcher` and was reused for matching-rule create/update responses.

**Fix scope:** Type split only — no runtime behavior change. `run()` already called the correct endpoint; typings were misleading.

**Parity:** Matches Core `StartReconciliation` handler (`gin.H{"reconciliation_id": ...}`, HTTP 200). `runInstant` already used the same response shape via `RunInstantReconResp`.

**Postman:** Folder `TS SDK (#121)` (matching rule → upload → start) to be added to the local collection separately.

Closes #121