### PR TITLE
fix(types): align dropped 0.15.0 response fields (closes #122)

### DIFF
--- a/CORE-0.15.0-GAP-CHECKLIST.md
+++ b/CORE-0.15.0-GAP-CHECKLIST.md
@@ -49,10 +49,10 @@
 
 | # | Area | Current SDK | Core 0.15.0 | Fix |
 |---|------|-------------|-------------|-----|
-| B1 | `Reconciliation.run` | `RunReconResp extends Matcher` | Returns only `{ reconciliation_id }` | 🚧 In progress [#121](https://github.com/blnkfinance/blnk-ts/issues/121) |
-| B2 | Transaction responses | `CreateTransactionResponse.rate` required | `rate` removed from responses | Make `rate?` optional or remove from response type |
-| B3 | Balance responses | `LedgerBalanceResp.currency_multiplier` required | Field removed | Make optional or remove from response type |
-| B4 | Search hit types | `currency_multiplier?`, `rate?` on documents | Fields removed from responses | Remove or mark deprecated optional |
+| B1 | `Reconciliation.run` | `RunReconResp extends Matcher` | Returns only `{ reconciliation_id }` | ✅ [#121](https://github.com/blnkfinance/blnk-ts/issues/121) |
+| B2 | Transaction responses | `CreateTransactionResponse.rate` required | `rate` removed from responses | 🚧 In progress [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
+| B3 | Balance responses | `LedgerBalanceResp.currency_multiplier` required | Field removed | 🚧 In progress [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
+| B4 | Search hit types | `currency_multiplier?`, `rate?` on documents | Fields removed from responses | 🚧 In progress [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
 | B5 | Inflight update response | No `queued` on `CreateTransactionResponse` | Default queued commit/void returns `queued: true` | Add `queued?: boolean` to transaction response type |
 | B6 | Bulk inflight results | `BulkInflightResultStatus = succeeded \| failed` | Results can be `queued` when not using `skip_queue` | Add `queued` to result status union + docs |
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ interface CreateTransactionResponse<T extends Record<string, unknown>> {
   precise_amount: number | string;
   reference: string;
   description: string;
-  rate: number;
+  rate?: number;
   currency: string;
   status: StatusType;
   hash: string;

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -20,7 +20,8 @@ export interface CreateLedgerBalanceResp<T extends Record<string, unknown>> {
   inflight_credit_balance: number;
   debit_balance: number;
   inflight_debit_balance: number;
-  currency_multiplier: number;
+  /** Removed from Core 0.15.0 balance responses. */
+  currency_multiplier?: number;
   ledger_id: string;
   identity_id: string;
   balance_id: string;

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -80,7 +80,6 @@ export interface SearchBalanceDocument {
   version?: number;
   allocation_strategy?: string;
   track_fund_lineage?: boolean;
-  currency_multiplier?: number;
   inflight_expires_at?: number;
   /** Typesense-indexed creation time (Unix timestamp seconds). */
   created_at: number;
@@ -108,7 +107,6 @@ export interface SearchTransactionDocument {
   allow_overdraft?: boolean;
   overdraft_limit?: number;
   skip_queue?: boolean;
-  rate?: number;
   /** Typesense-indexed creation time (Unix timestamp seconds). */
   created_at: number;
   scheduled_for?: number;

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -71,7 +71,8 @@ export type CreateTransactionResponse<T extends Record<string, unknown>> = {
   precise_amount: number | string;
   reference: string;
   description: string;
-  rate: number;
+  /** Removed from Core 0.15.0 responses; optional for request bodies and legacy payloads. */
+  rate?: number;
   currency: string;
   status: StatusType;
   /** SHA-256 hash of the transaction details. */

--- a/tests/fixtures/coreCreateTransactionResponse.ts
+++ b/tests/fixtures/coreCreateTransactionResponse.ts
@@ -8,7 +8,6 @@ export const coreCreateTransactionReferenceResponse: CreateTransactionResponse<
   Record<string, never>
 > = {
   amount: 1250.34,
-  rate: 0,
   precision: 100,
   precise_amount: 125034,
   transaction_id: `txn_c4e70eb8-e4d6-4e04-a2e2-92a43b969e0c`,

--- a/tests/mocks/mockTransactions.ts
+++ b/tests/mocks/mockTransactions.ts
@@ -86,7 +86,6 @@ export function createDummyTransactionResponse<
     amount: 1000,
     precision: 2,
     precise_amount: 100000,
-    rate: 0,
     reference: `REF12345`,
     description: `Sample transaction description`,
     currency: `USD` as Currency,

--- a/tests/unit/types/createTransactionResponse.test.ts
+++ b/tests/unit/types/createTransactionResponse.test.ts
@@ -4,6 +4,15 @@ import {coreCreateTransactionReferenceResponse} from "../../fixtures/coreCreateT
 import {CreateTransactionResponse} from "../../../src/types/transactions";
 
 tap.test(`Issue #43 — CreateTransactionResponse API parity`, t => {
+  t.test(`accepts Core 0.15.0 create response without rate`, tt => {
+    const response: CreateTransactionResponse<Record<string, never>> = {
+      ...coreCreateTransactionReferenceResponse,
+    };
+
+    tt.equal(response.rate, undefined);
+    tt.end();
+  });
+
   t.test(`accepts Core API reference create response`, tt => {
     const response: CreateTransactionResponse<Record<string, never>> =
       coreCreateTransactionReferenceResponse;

--- a/tests/unit/types/droppedResponseFields.test.ts
+++ b/tests/unit/types/droppedResponseFields.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable n/no-unpublished-import */
+import tap from "tap";
+import {CreateLedgerBalanceResp} from "../../../src/types/ledgerBalances";
+import {
+  SearchBalanceDocument,
+  SearchTransactionDocument,
+} from "../../../src/types/search";
+import {CreateTransactionResponse} from "../../../src/types/transactions";
+
+tap.test(`Issue #122 — Core 0.15.0 dropped response fields`, t => {
+  t.test(`CreateTransactionResponse accepts response without rate`, tt => {
+    const response: CreateTransactionResponse<Record<string, never>> = {
+      transaction_id: `txn_test_123`,
+      amount: 10,
+      precision: 100,
+      precise_amount: 1000,
+      reference: `ref_001`,
+      description: `test`,
+      currency: `USD`,
+      status: `QUEUED`,
+      hash: `0b9c25fb5b00d6c71cb4ca87026bf6dc316e63353d3330deb588bd0b3d74dcc0`,
+      parent_transaction: ``,
+      allow_overdraft: false,
+      inflight: false,
+      created_at: `2026-06-24T00:00:00Z`,
+      scheduled_for: `0001-01-01T00:00:00Z`,
+      inflight_expiry_date: `0001-01-01T00:00:00Z`,
+      inflight_commit_date: `0001-01-01T00:00:00Z`,
+    };
+
+    tt.equal(response.rate, undefined);
+    tt.end();
+  });
+
+  t.test(`CreateLedgerBalanceResp accepts response without currency_multiplier`, tt => {
+    const response: CreateLedgerBalanceResp<Record<string, never>> = {
+      balance: 0,
+      version: 0,
+      inflight_balance: 0,
+      credit_balance: 0,
+      inflight_credit_balance: 0,
+      debit_balance: 0,
+      inflight_debit_balance: 0,
+      ledger_id: `ldg_test`,
+      identity_id: ``,
+      balance_id: `bln_test`,
+      indicator: ``,
+      currency: `USD`,
+      created_at: `2026-06-24T00:00:00Z`,
+    };
+
+    tt.equal(response.currency_multiplier, undefined);
+    tt.end();
+  });
+
+  t.test(`SearchTransactionDocument omits rate`, tt => {
+    const document: SearchTransactionDocument = {
+      id: `txn_test`,
+      transaction_id: `txn_test`,
+      status: `APPLIED`,
+      created_at: 1781028226,
+    };
+
+    tt.equal(`rate` in document, false);
+    tt.end();
+  });
+
+  t.test(`SearchBalanceDocument omits currency_multiplier`, tt => {
+    const document: SearchBalanceDocument = {
+      id: `bln_test`,
+      balance_id: `bln_test`,
+      balance: `0`,
+      created_at: 1781222909,
+    };
+
+    tt.equal(`currency_multiplier` in document, false);
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
## Summary

- `CreateTransactionResponse.rate` is now optional (removed from Core 0.15.0 transaction responses)
- `CreateLedgerBalanceResp.currency_multiplier` is now optional (removed from Core 0.15.0 balance responses)
- `SearchTransactionDocument` and `SearchBalanceDocument` no longer include `rate` / `currency_multiplier`
- Fixtures, mocks, and unit tests updated for 0.15.0 response shapes

## Test plan

- [x] `npm run test:unit` — 996 pass (5 new/updated in `droppedResponseFields.test.ts` + `createTransactionResponse.test.ts`)
- [x] Live Core 0.15.0: `POST /balances` response has no `currency_multiplier`; `POST /transactions` response has no `rate`

## Self-review

**Scope:** Type-only alignment with Core 0.15.0 migration — no runtime SDK behavior changes.

**Backward compatibility:** `rate` and `currency_multiplier` remain optional on types so legacy payloads still type-check; search document types drop fields Core no longer indexes.

**Request types unchanged:** `CreateTransactions.rate?` was already optional for request bodies.

Closes #122