### PR TITLE
fix(validators): bulk create max 10,000 items (closes #123)

### DIFF
--- a/CORE-0.15.0-GAP-CHECKLIST.md
+++ b/CORE-0.15.0-GAP-CHECKLIST.md
@@ -50,9 +50,9 @@
 | # | Area | Current SDK | Core 0.15.0 | Fix |
 |---|------|-------------|-------------|-----|
 | B1 | `Reconciliation.run` | `RunReconResp extends Matcher` | Returns only `{ reconciliation_id }` | ✅ [#121](https://github.com/blnkfinance/blnk-ts/issues/121) |
-| B2 | Transaction responses | `CreateTransactionResponse.rate` required | `rate` removed from responses | 🚧 In progress [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
-| B3 | Balance responses | `LedgerBalanceResp.currency_multiplier` required | Field removed | 🚧 In progress [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
-| B4 | Search hit types | `currency_multiplier?`, `rate?` on documents | Fields removed from responses | 🚧 In progress [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
+| B2 | Transaction responses | `CreateTransactionResponse.rate` required | `rate` removed from responses | ✅ [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
+| B3 | Balance responses | `LedgerBalanceResp.currency_multiplier` required | Field removed | ✅ [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
+| B4 | Search hit types | `currency_multiplier?`, `rate?` on documents | Fields removed from responses | ✅ [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
 | B5 | Inflight update response | No `queued` on `CreateTransactionResponse` | Default queued commit/void returns `queued: true` | Add `queued?: boolean` to transaction response type |
 | B6 | Bulk inflight results | `BulkInflightResultStatus = succeeded \| failed` | Results can be `queued` when not using `skip_queue` | Add `queued` to result status union + docs |
 
@@ -62,7 +62,7 @@
 
 | # | Validator | Current | Core 0.15.0 | Fix |
 |---|-----------|---------|-------------|-----|
-| C1 | `ValidateBulkTransactions` | No max length | Max **10,000** transactions | Add `MAX_BULK_CREATE_ITEMS = 10000` check (mirror instant recon) |
+| C1 | `ValidateBulkTransactions` | No max length | Max **10,000** transactions | ✅ `MAX_BULK_CREATE_ITEMS = 10000` |
 | C2 | `ValidateUpdateTransactions` | Rejects `skip_queue` (not in allowedFields) | `skip_queue` supported on inflight commit/void | Add `skip_queue?: boolean` to `UpdateTransactionStatus` + validator |
 | C3 | Bulk commit/void types | No `skip_queue` on request types | Supported on bulk commit/void | Add to `BulkCommitInflightRequest`, `BulkVoidInflightRequest` + validators |
 

--- a/README.md
+++ b/README.md
@@ -702,10 +702,11 @@ The bulk API returns batch metadata (not nested transaction objects). See **Bulk
 The bulk transactions API validates the following:
 
 1. **Required Fields**: `transactions` array must be provided and cannot be empty
-2. **Transaction Validation**: Each transaction in the array must pass standard transaction validation
-3. **Unique References**: All transaction references must be unique within the bulk request
-4. **Boolean Flags**: `atomic`, `inflight`, `run_async`, and `skip_queue` must be booleans if provided
-5. **Standard Transaction Rules**: All existing transaction validation rules apply to each transaction
+2. **Max Size**: `transactions` array cannot exceed **10,000** items
+3. **Transaction Validation**: Each transaction in the array must pass standard transaction validation
+4. **Unique References**: All transaction references must be unique within the bulk request
+5. **Boolean Flags**: `atomic`, `inflight`, `run_async`, and `skip_queue` must be booleans if provided
+6. **Standard Transaction Rules**: All existing transaction validation rules apply to each transaction
 
 ### Error Handling
 

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -4,6 +4,7 @@ import {
   BulkVoidInflightRequest,
   BulkTransactions,
   CreateTransactions,
+  MAX_BULK_CREATE_ITEMS,
   MAX_BULK_INFLIGHT_ITEMS,
   MultipleSourcesT,
   RecoverQueueRequest,
@@ -692,6 +693,10 @@ export function ValidateBulkTransactions<T extends Record<string, unknown>>(
 
   if (data.transactions.length === 0) {
     return `Transactions array cannot be empty.`;
+  }
+
+  if (data.transactions.length > MAX_BULK_CREATE_ITEMS) {
+    return `Too many transactions; max is ${MAX_BULK_CREATE_ITEMS}.`;
   }
 
   for (let i = 0; i < data.transactions.length; i++) {

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -188,6 +188,9 @@ export interface BulkTransactionResponse {
 /** Maximum items per bulk commit or bulk void inflight request. */
 export const MAX_BULK_INFLIGHT_ITEMS = 100;
 
+/** Maximum items per `POST /transactions/bulk` request (Core 0.15.0). */
+export const MAX_BULK_CREATE_ITEMS = 10000;
+
 /** One transaction in `POST /transactions/inflight/bulk/commit`. */
 export interface BulkCommitInflightItem {
   transaction_id: string;

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -14,6 +14,7 @@ import {
   BulkTransactions,
   CreateTransactionResponse,
   CreateTransactions,
+  MAX_BULK_CREATE_ITEMS,
   MAX_BULK_INFLIGHT_ITEMS,
   RefundTransactionRequest,
   UpdateTransactionStatus,
@@ -1181,6 +1182,42 @@ tap.test(`Creates bulk transactions`, async t => {
         [`transactions/bulk`, data, `POST`],
       ]);
       childTest.equal(bulkResponse.status, 201);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `createBulk rejects oversized transactions array (issue #123)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: BulkTransactions<meta_dataT> = {
+        transactions: Array.from({length: MAX_BULK_CREATE_ITEMS + 1}, (_, i) => ({
+          amount: 1000,
+          currency: `USD`,
+          description: `Bulk txn ${i}`,
+          precision: 100,
+          reference: `bulk_max_ref_${i}`,
+          source: `@source_account`,
+          destination: `@destination_account`,
+        })),
+      };
+
+      const response = await transactions.createBulk<meta_dataT>(data);
+      childTest.match(capturedRequest.args(), []);
+      childTest.equal(response.data, null);
+      childTest.equal(response.status, 400);
+      childTest.match(
+        response.message,
+        new RegExp(
+          `Too many transactions; max is ${MAX_BULK_CREATE_ITEMS}\\.`,
+        ),
+      );
       childTest.end();
     },
   );

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -14,6 +14,7 @@ import {
   BulkVoidInflightRequest,
   BulkTransactions,
   CreateTransactions,
+  MAX_BULK_CREATE_ITEMS,
   MAX_BULK_INFLIGHT_ITEMS,
   RecoverQueueRequest,
   RefundTransactionRequest,
@@ -812,6 +813,22 @@ tap.test(`Issue #44 — bulk transaction request fields`, t => {
     tt.equal(
       ValidateBulkTransactions(data),
       `skip_queue must be a boolean if provided.`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects oversized transactions array (issue #123)`, tt => {
+    const transactions = Array.from(
+      {length: MAX_BULK_CREATE_ITEMS + 1},
+      (_, i) => ({
+        ...baseBulkTxn,
+        reference: `bulk_ref_${i}`,
+      }),
+    );
+
+    tt.equal(
+      ValidateBulkTransactions({transactions}),
+      `Too many transactions; max is ${MAX_BULK_CREATE_ITEMS}.`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Add `MAX_BULK_CREATE_ITEMS = 10000` and enforce it in `ValidateBulkTransactions` before per-item validation (mirrors Core 0.15.0 `MaxBulkTransactionItems`).
- Export the constant from `src/types/transactions.ts` alongside `MAX_BULK_INFLIGHT_ITEMS`.
- Document the 10,000-item limit in README bulk validation rules.
- Mark checklist items **C1** and **B2–B4** complete.

## Test plan
- [x] `npm run test:unit` — 1003 pass (+2 new tests: validator + `createBulk` endpoint)
- [x] Oversized bulk request returns 400 without calling the API