### PR TITLE
fix(inflight): queued default + skip_queue parity (closes #117)

### DIFF
--- a/CORE-0.15.0-GAP-CHECKLIST.md
+++ b/CORE-0.15.0-GAP-CHECKLIST.md
@@ -53,8 +53,8 @@
 | B2 | Transaction responses | `CreateTransactionResponse.rate` required | `rate` removed from responses | ✅ [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
 | B3 | Balance responses | `LedgerBalanceResp.currency_multiplier` required | Field removed | ✅ [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
 | B4 | Search hit types | `currency_multiplier?`, `rate?` on documents | Fields removed from responses | ✅ [#122](https://github.com/blnkfinance/blnk-ts/issues/122) |
-| B5 | Inflight update response | No `queued` on `CreateTransactionResponse` | Default queued commit/void returns `queued: true` | Add `queued?: boolean` to transaction response type |
-| B6 | Bulk inflight results | `BulkInflightResultStatus = succeeded \| failed` | Results can be `queued` when not using `skip_queue` | Add `queued` to result status union + docs |
+| B5 | Inflight update response | No `queued` on `CreateTransactionResponse` | Default queued commit/void returns `queued: true` | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
+| B6 | Bulk inflight results | `BulkInflightResultStatus = succeeded \| failed` | Results can be `queued` when not using `skip_queue` | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
 
 ---
 
@@ -63,8 +63,8 @@
 | # | Validator | Current | Core 0.15.0 | Fix |
 |---|-----------|---------|-------------|-----|
 | C1 | `ValidateBulkTransactions` | No max length | Max **10,000** transactions | ✅ `MAX_BULK_CREATE_ITEMS = 10000` |
-| C2 | `ValidateUpdateTransactions` | Rejects `skip_queue` (not in allowedFields) | `skip_queue` supported on inflight commit/void | Add `skip_queue?: boolean` to `UpdateTransactionStatus` + validator |
-| C3 | Bulk commit/void types | No `skip_queue` on request types | Supported on bulk commit/void | Add to `BulkCommitInflightRequest`, `BulkVoidInflightRequest` + validators |
+| C2 | `ValidateUpdateTransactions` | Rejects `skip_queue` (not in allowedFields) | `skip_queue` supported on inflight commit/void | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
+| C3 | Bulk commit/void types | No `skip_queue` on request types | Supported on bulk commit/void | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
 
 **Note:** Bulk commit/void max **100** items is already enforced (`MAX_BULK_INFLIGHT_ITEMS = 100`). ✅
 
@@ -74,9 +74,9 @@
 
 | # | Task | Notes |
 |---|------|-------|
-| D1 | Document queued default in README | Commit/void/bulk inflight return queued unless `skip_queue: true` |
-| D2 | Integration tests on Core 0.15.0 | Verify default queued response; verify `skip_queue: true` sync path |
-| D3 | Postman folders | Add cases for queued vs sync inflight commit/void |
+| D1 | Document queued default in README | Commit/void/bulk inflight return queued unless `skip_queue: true` | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
+| D2 | Integration tests on Core 0.15.0 | Verify default queued response; verify `skip_queue: true` sync path | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
+| D3 | Postman folders | Add cases for queued vs sync inflight commit/void | ✅ [#117](https://github.com/blnkfinance/blnk-ts/issues/117) |
 | D4 | Reconciliation webhooks note | README/changelog: use `reconciliation.completed` / `reconciliation.failed` webhooks after start |
 
 ---

--- a/README.md
+++ b/README.md
@@ -446,25 +446,36 @@ const response = await Transactions.getLineage('txn_8d2ce2f0-0d75-4a91-9d43-2ad2
 
 ### Update inflight transaction status
 
+Core **0.15.0** queues inflight commit and void by default. The response includes `queued: true` (status is typically `QUEUED` until the worker processes the action). Send `skip_queue: true` for immediate `APPLIED` or `VOID` responses (previous synchronous behavior).
+
 `Transactions.updateStatus` accepts `precise_amount` for partial commits on inflight transactions (in addition to `amount`). Omit both fields to commit the full remaining inflight amount:
 
 ```typescript
+// Queued commit (default in Core 0.15.0)
+const queued = await Transactions.updateStatus(transactionId, { status: 'commit' });
+// queued.data?.queued === true
+
+// Synchronous commit
+await Transactions.updateStatus(transactionId, {
+  status: 'commit',
+  skip_queue: true,
+});
+
 // Partial commit in minor units
 await Transactions.updateStatus(transactionId, {
   status: 'commit',
   precise_amount: 50000,
+  skip_queue: true,
 });
-
-// Full commit
-await Transactions.updateStatus(transactionId, { status: 'commit' });
 ```
 
 ### Bulk commit inflight transactions
 
-`Transactions.bulkCommitInflight` commits multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/commit`). Omit `amount` and `precise_amount` on an item to commit the full remaining inflight amount:
+`Transactions.bulkCommitInflight` commits multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/commit`). By default, each item is queued (`status: 'queued'` in results). Pass `skip_queue: true` for synchronous processing. Omit `amount` and `precise_amount` on an item to commit the full remaining inflight amount:
 
 ```typescript
 const response = await Transactions.bulkCommitInflight({
+  skip_queue: true,
   transactions: [
     { transaction_id: 'txn_11111111-1111-4111-8111-111111111111' },
     { transaction_id: 'txn_22222222-2222-4222-8222-222222222222', amount: 40 },
@@ -480,10 +491,11 @@ const response = await Transactions.bulkCommitInflight({
 
 ### Bulk void inflight transactions
 
-`Transactions.bulkVoidInflight` voids multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/void`):
+`Transactions.bulkVoidInflight` voids multiple independently-created inflight transactions in one request (`POST /transactions/inflight/bulk/void`). By default, each item is queued. Pass `skip_queue: true` for synchronous void:
 
 ```typescript
 const response = await Transactions.bulkVoidInflight({
+  skip_queue: true,
   transaction_ids: [
     'txn_11111111-1111-4111-8111-111111111111',
     'txn_22222222-2222-4222-8222-222222222222',

--- a/src/blnk/utils/validators/transactionValidators.ts
+++ b/src/blnk/utils/validators/transactionValidators.ts
@@ -570,7 +570,17 @@ export function ValidateUpdateTransactions<T extends Record<string, unknown>>(
     return `meta_data must be a valid object if provided`;
   }
 
-  const allowedFields = [`status`, `amount`, `precise_amount`, `meta_data`];
+  if (data.skip_queue !== undefined && typeof data.skip_queue !== `boolean`) {
+    return `skip_queue must be a boolean if provided.`;
+  }
+
+  const allowedFields = [
+    `status`,
+    `amount`,
+    `precise_amount`,
+    `meta_data`,
+    `skip_queue`,
+  ];
   for (const key in data) {
     if (!allowedFields.includes(key)) {
       return `Invalid field: ${key}`;
@@ -600,6 +610,10 @@ export function ValidateRefundTransaction(
 export function ValidateBulkVoidInflight(
   data: BulkVoidInflightRequest,
 ): string | null {
+  if (data.skip_queue !== undefined && typeof data.skip_queue !== `boolean`) {
+    return `skip_queue must be a boolean if provided.`;
+  }
+
   if (!Array.isArray(data.transaction_ids)) {
     return `transaction_ids must be an array.`;
   }
@@ -620,12 +634,23 @@ export function ValidateBulkVoidInflight(
     }
   }
 
+  const allowedFields = [`skip_queue`, `transaction_ids`];
+  for (const key in data) {
+    if (!allowedFields.includes(key)) {
+      return `Invalid field: ${key}`;
+    }
+  }
+
   return null;
 }
 
 export function ValidateBulkCommitInflight(
   data: BulkCommitInflightRequest,
 ): string | null {
+  if (data.skip_queue !== undefined && typeof data.skip_queue !== `boolean`) {
+    return `skip_queue must be a boolean if provided.`;
+  }
+
   if (!Array.isArray(data.transactions)) {
     return `Transactions must be an array.`;
   }
@@ -662,6 +687,13 @@ export function ValidateBulkCommitInflight(
       if (parsePreciseInteger(item.precise_amount) === null) {
         return `precise_amount must be a non-negative integer string or number at index ${i}.`;
       }
+    }
+  }
+
+  const allowedFields = [`skip_queue`, `transactions`];
+  for (const key in data) {
+    if (!allowedFields.includes(key)) {
+      return `Invalid field: ${key}`;
     }
   }
 

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -86,6 +86,8 @@ export type CreateTransactionResponse<T extends Record<string, unknown>> = {
   allow_overdraft: boolean;
   skip_queue?: boolean;
   inflight: boolean;
+  /** When true, commit/void was queued for async processing (Core 0.15.0 default). */
+  queued?: boolean;
   /** When true, all split legs succeed or fail together. */
   atomic?: boolean;
   overdraft_limit?: number;
@@ -150,6 +152,8 @@ export type UpdateTransactionStatus<T extends Record<string, unknown>> = {
    */
   precise_amount?: number | string;
   meta_data?: T;
+  /** Process synchronously without queuing. Default: `false` (Core 0.15.0 queues commit/void). */
+  skip_queue?: boolean;
 };
 
 /** Optional body for `POST /refund-transaction/{transaction_id}`. */
@@ -208,10 +212,12 @@ export interface BulkCommitInflightItem {
 
 /** Request body for `POST /transactions/inflight/bulk/commit`. */
 export interface BulkCommitInflightRequest {
+  /** Process synchronously without queuing. Default: `false` (Core 0.15.0 queues commit/void). */
+  skip_queue?: boolean;
   transactions: BulkCommitInflightItem[];
 }
 
-export type BulkInflightResultStatus = `succeeded` | `failed`;
+export type BulkInflightResultStatus = `succeeded` | `failed` | `queued`;
 
 /** Per-item outcome in `BulkCommitInflightResponse`. */
 export interface BulkCommitInflightResult {
@@ -234,6 +240,8 @@ export interface BulkCommitInflightResponse {
 
 /** Request body for `POST /transactions/inflight/bulk/void`. */
 export interface BulkVoidInflightRequest {
+  /** Process synchronously without queuing. Default: `false` (Core 0.15.0 queues commit/void). */
+  skip_queue?: boolean;
   transaction_ids: string[];
 }
 

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -387,10 +387,100 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
 
     const partialCommitResp = await client.Transactions.updateStatus(
       createResp.data!.transaction_id,
-      {status: `commit`, precise_amount: 50000},
+      {status: `commit`, precise_amount: 50000, skip_queue: true},
     );
     tt.equal(partialCommitResp.status, 200);
     tt.equal(partialCommitResp.data?.status, `APPLIED`);
+    tt.end();
+  });
+
+  // Issue #117 — queued default + skip_queue on inflight commit/void
+  t.test(`#117 updateStatus queued by default`, async tt => {
+    const ledgerId = await createLedger(`Issue117 QueuedCommit`);
+    const destination = await createBalance(ledgerId);
+
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 5000,
+      reference: GenerateRandomNumbersWithPrefix(`issue117-queued`, 6),
+      source: `@FundingPool`,
+      destination,
+      inflight: true,
+      inflight_expiry_date: `2026-12-31T23:59:59Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    await Sleep(2);
+
+    const commitResp = await client.Transactions.updateStatus(
+      createResp.data!.transaction_id,
+      {status: `commit`},
+    );
+    tt.equal(commitResp.status, 200);
+    tt.equal(commitResp.data?.queued, true);
+    tt.end();
+  });
+
+  t.test(`#117 updateStatus skip_queue synchronous commit`, async tt => {
+    const ledgerId = await createLedger(`Issue117 SyncCommit`);
+    const destination = await createBalance(ledgerId);
+
+    const createResp = await client.Transactions.create({
+      ...baseTxn,
+      amount: 5000,
+      reference: GenerateRandomNumbersWithPrefix(`issue117-sync`, 6),
+      source: `@FundingPool`,
+      destination,
+      inflight: true,
+      inflight_expiry_date: `2026-12-31T23:59:59Z`,
+    } as CreateTransactions<Record<string, never>>);
+
+    tt.equal(createResp.status, 201);
+    await Sleep(2);
+
+    const commitResp = await client.Transactions.updateStatus(
+      createResp.data!.transaction_id,
+      {status: `commit`, skip_queue: true},
+    );
+    tt.equal(commitResp.status, 200);
+    tt.equal(commitResp.data?.status, `APPLIED`);
+    tt.end();
+  });
+
+  t.test(`#117 bulkCommitInflight queued vs skip_queue`, async tt => {
+    const ledgerId = await createLedger(`Issue117 BulkCommit`);
+    const destination = await createBalance(ledgerId);
+
+    async function createInflight(refPrefix: string) {
+      const createResp = await client.Transactions.create({
+        ...baseTxn,
+        amount: 1000,
+        reference: GenerateRandomNumbersWithPrefix(refPrefix, 6),
+        source: `@FundingPool`,
+        destination,
+        inflight: true,
+        inflight_expiry_date: `2026-12-31T23:59:59Z`,
+      } as CreateTransactions<Record<string, never>>);
+      tt.equal(createResp.status, 201);
+      return createResp.data!.transaction_id;
+    }
+
+    const txnQueued = await createInflight(`issue117-bulk-q`);
+    const txnSync = await createInflight(`issue117-bulk-s`);
+    await Sleep(2);
+
+    const queuedResp = await client.Transactions.bulkCommitInflight({
+      transactions: [{transaction_id: txnQueued}],
+    });
+    tt.equal(queuedResp.status, 200);
+    tt.equal(queuedResp.data?.results?.[0]?.status, `queued`);
+
+    const syncResp = await client.Transactions.bulkCommitInflight({
+      skip_queue: true,
+      transactions: [{transaction_id: txnSync}],
+    });
+    tt.equal(syncResp.status, 200);
+    tt.equal(syncResp.data?.results?.[0]?.status, `succeeded`);
     tt.end();
   });
 

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -15,10 +15,10 @@ import {
   BulkTransactions,
   CreateTransactions,
 } from "../../src/types/transactions";
-import {BASE_URL, GenerateRandomNumbersWithPrefix, Sleep} from "../utils.test";
+import {BASE_URL, BLNK_API_KEY, GenerateRandomNumbersWithPrefix, Sleep} from "../utils.test";
 
 const clientOptions: BlnkClientOptions = {baseUrl: BASE_URL};
-const client = BlnkInit(``, clientOptions);
+const client = BlnkInit(BLNK_API_KEY, clientOptions);
 
 const baseTxn = {
   precision: 100,
@@ -478,6 +478,43 @@ tap.test(`SDK integration — each added capability vs Blnk Core`, async t => {
     const syncResp = await client.Transactions.bulkCommitInflight({
       skip_queue: true,
       transactions: [{transaction_id: txnSync}],
+    });
+    tt.equal(syncResp.status, 200);
+    tt.equal(syncResp.data?.results?.[0]?.status, `succeeded`);
+    tt.end();
+  });
+
+  t.test(`#117 bulkVoidInflight queued vs skip_queue`, async tt => {
+    const ledgerId = await createLedger(`Issue117 BulkVoid`);
+    const destination = await createBalance(ledgerId);
+
+    async function createInflight(refPrefix: string) {
+      const createResp = await client.Transactions.create({
+        ...baseTxn,
+        amount: 1000,
+        reference: GenerateRandomNumbersWithPrefix(refPrefix, 6),
+        source: `@FundingPool`,
+        destination,
+        inflight: true,
+        inflight_expiry_date: `2026-12-31T23:59:59Z`,
+      } as CreateTransactions<Record<string, never>>);
+      tt.equal(createResp.status, 201);
+      return createResp.data!.transaction_id;
+    }
+
+    const txnQueued = await createInflight(`issue117-bulk-void-q`);
+    const txnSync = await createInflight(`issue117-bulk-void-s`);
+    await Sleep(2);
+
+    const queuedResp = await client.Transactions.bulkVoidInflight({
+      transaction_ids: [txnQueued],
+    });
+    tt.equal(queuedResp.status, 200);
+    tt.equal(queuedResp.data?.results?.[0]?.status, `queued`);
+
+    const syncResp = await client.Transactions.bulkVoidInflight({
+      skip_queue: true,
+      transaction_ids: [txnSync],
     });
     tt.equal(syncResp.status, 200);
     tt.equal(syncResp.data?.results?.[0]?.status, `succeeded`);

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -487,6 +487,56 @@ tap.test(`Updates a transaction`, async t => {
       childTest.equal(transaction.status, 400);
     },
   );
+
+  t.test(
+    `updateStatus forwards skip_queue on request (issue #117)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: UpdateTransactionStatus<{}> = {
+        status: `commit`,
+        skip_queue: true,
+      };
+
+      const transaction = await transactions.updateStatus(id, data);
+      childTest.match(capturedRequest.args(), [
+        [`transactions/inflight/${id}`, data, `PUT`],
+      ]);
+      childTest.equal(transaction.status, 200);
+      childTest.end();
+    },
+  );
+
+  t.test(
+    `updateStatus rejects invalid skip_queue (issue #117)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data = {
+        status: `commit`,
+        skip_queue: `true`,
+      } as unknown as UpdateTransactionStatus<{}>;
+
+      const transaction = await transactions.updateStatus(id, data);
+      childTest.match(capturedRequest.args(), []);
+      childTest.equal(transaction.status, 400);
+      childTest.match(
+        transaction.message,
+        /skip_queue must be a boolean if provided/,
+      );
+      childTest.end();
+    },
+  );
 });
 
 tap.test(`GET transaction by id`, async t => {
@@ -1319,6 +1369,32 @@ tap.test(`Issue #15 — bulkCommitInflight`, async t => {
     childTest.equal(response.message, `transaction_id is required at index 0.`);
     childTest.end();
   });
+
+  t.test(
+    `bulkCommitInflight forwards skip_queue on request (issue #117)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: BulkCommitInflightRequest = {
+        skip_queue: true,
+        transactions: [
+          {transaction_id: `txn_11111111-1111-4111-8111-111111111111`},
+        ],
+      };
+
+      const response = await transactions.bulkCommitInflight(data);
+      childTest.match(capturedRequest.args(), [
+        [`transactions/inflight/bulk/commit`, data, `POST`],
+      ]);
+      childTest.equal(response.status, 200);
+      childTest.end();
+    },
+  );
 });
 
 tap.test(`Issue #16 — bulkVoidInflight`, async t => {
@@ -1409,4 +1485,28 @@ tap.test(`Issue #16 — bulkVoidInflight`, async t => {
     childTest.equal(response.message, `transaction_id is required at index 0.`);
     childTest.end();
   });
+
+  t.test(
+    `bulkVoidInflight forwards skip_queue on request (issue #117)`,
+    async childTest => {
+      const capturedRequest = childTest.captureFn(thirdPartyRequest);
+      const transactions = new Transactions(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
+
+      const data: BulkVoidInflightRequest = {
+        skip_queue: true,
+        transaction_ids: [`txn_11111111-1111-4111-8111-111111111111`],
+      };
+
+      const response = await transactions.bulkVoidInflight(data);
+      childTest.match(capturedRequest.args(), [
+        [`transactions/inflight/bulk/void`, data, `POST`],
+      ]);
+      childTest.equal(response.status, 200);
+      childTest.end();
+    },
+  );
 });

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -901,6 +901,29 @@ tap.test(`Issue #45 — updateStatus precise_amount on partial commit`, t => {
     tt.end();
   });
 
+  t.test(`allows skip_queue on update payloads (issue #117)`, tt => {
+    const data: UpdateTransactionStatus<Record<string, never>> = {
+      status: `commit`,
+      skip_queue: true,
+    };
+
+    tt.equal(ValidateUpdateTransactions(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid skip_queue on update payloads (issue #117)`, tt => {
+    const data = {
+      status: `commit`,
+      skip_queue: `true`,
+    } as unknown as UpdateTransactionStatus<Record<string, never>>;
+
+    tt.equal(
+      ValidateUpdateTransactions(data),
+      `skip_queue must be a boolean if provided.`,
+    );
+    tt.end();
+  });
+
   t.end();
 });
 
@@ -994,6 +1017,29 @@ tap.test(`Issue #15 — bulkCommitInflight validation`, t => {
     tt.end();
   });
 
+  t.test(`allows skip_queue on bulk commit payloads (issue #117)`, tt => {
+    const data: BulkCommitInflightRequest = {
+      skip_queue: true,
+      transactions: [{transaction_id: `txn_11111111-1111-4111-8111-111111111111`}],
+    };
+
+    tt.equal(ValidateBulkCommitInflight(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid skip_queue on bulk commit payloads (issue #117)`, tt => {
+    const data = {
+      skip_queue: `true`,
+      transactions: [{transaction_id: `txn_11111111-1111-4111-8111-111111111111`}],
+    } as unknown as BulkCommitInflightRequest;
+
+    tt.equal(
+      ValidateBulkCommitInflight(data),
+      `skip_queue must be a boolean if provided.`,
+    );
+    tt.end();
+  });
+
   t.end();
 });
 
@@ -1035,6 +1081,29 @@ tap.test(`Issue #16 — bulkVoidInflight validation`, t => {
     tt.equal(
       ValidateBulkVoidInflight({transaction_ids: [``]}),
       `transaction_id is required at index 0.`,
+    );
+    tt.end();
+  });
+
+  t.test(`allows skip_queue on bulk void payloads (issue #117)`, tt => {
+    const data: BulkVoidInflightRequest = {
+      skip_queue: true,
+      transaction_ids: [`txn_11111111-1111-4111-8111-111111111111`],
+    };
+
+    tt.equal(ValidateBulkVoidInflight(data), null);
+    tt.end();
+  });
+
+  t.test(`rejects invalid skip_queue on bulk void payloads (issue #117)`, tt => {
+    const data = {
+      skip_queue: `true`,
+      transaction_ids: [`txn_11111111-1111-4111-8111-111111111111`],
+    } as unknown as BulkVoidInflightRequest;
+
+    tt.equal(
+      ValidateBulkVoidInflight(data),
+      `skip_queue must be a boolean if provided.`,
     );
     tt.end();
   });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -14,3 +14,7 @@ export function Sleep(seconds: number) {
 }
 
 export const BASE_URL = `http://localhost:5001/`;
+
+/** Local Core dev key; override with BLNK_API_KEY when running integration tests. */
+export const BLNK_API_KEY =
+  process.env.BLNK_API_KEY ?? `blnk-local-dev-secret-change-me`;


### PR DESCRIPTION
## Summary
- Add `skip_queue?: boolean` to `UpdateTransactionStatus`, `BulkCommitInflightRequest`, and `BulkVoidInflightRequest` with validator support.
- Add `queued?: boolean` to `CreateTransactionResponse` and `queued` to `BulkInflightResultStatus`.
- Document Core 0.15.0 queued default behavior in README (commit/void/bulk inflight).
- Integration tests for queued vs synchronous paths; Postman folder **`TS SDK (#117)`** added.

## Test plan
- [x] `npm run test:unit` — 1028 pass (+10 new tests)
- [ ] Run **`TS SDK (#117)`** folder in Postman (No environment + Keep variable values; run **Setup** first)
- [ ] `npx tap tests/integration/sdk-issues.integration.test.ts` against Core 0.15.0