### PR TITLE
sdk(release): bump version to 1.3.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blnkfinance/blnk-typescript",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blnkfinance/blnk-typescript",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blnkfinance/blnk-typescript",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Blnk Finance SDK in TypeScript",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `@blnkfinance/blnk-typescript` to **1.3.0** (targets Blnk Core **0.15.0**).

## Test plan
- [x] `npm run test:unit` — 1056 pass