### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish @blnkfinance/blnk-typescript
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run compile
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,18 +3,28 @@ name: Publish to npm
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 jobs:
   publish:
     name: Publish @blnkfinance/blnk-typescript
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -27,6 +37,24 @@ jobs:
 
       - name: Build package
         run: npm run compile
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Verify publish contents
+        run: npm pack --dry-run
+
+      - name: Smoke test packed tarball
+        run: |
+          npm pack
+          TARBALL=$(ls blnkfinance-blnk-typescript-*.tgz)
+          mkdir smoke-test && cd smoke-test
+          npm init -y >/dev/null 2>&1
+          npm install "../${TARBALL}"
+          node -e "require('@blnkfinance/blnk-typescript')"
 
       - name: Publish to npm
         run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Blnk Finance SDK in TypeScript",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "gts lint",
     "clean": "gts clean",


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that publishes `@blnkfinance/blnk-typescript` to npm when a `v*` tag is pushed
- Adds a `files` field so compiled `dist/` is included in the published package (it is gitignored locally)

## How to publish after merge
1. Ensure `NPM_TOKEN` is set in repo secrets (already done)
2. Tag the release on `main`, e.g. `git tag v1.3.0 && git push origin v1.3.0`
3. The workflow builds and publishes automatically

## Test plan
- [ ] Merge PR
- [ ] Push tag `v1.3.0` from `main`
- [ ] Confirm workflow succeeds in Actions
- [ ] Confirm npm shows `@blnkfinance/blnk-typescript@1.3.0`