### PR TITLE
fix(client): satisfy formatResponse type for nullable JSON bodies

### DIFF
--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -228,7 +228,7 @@ export class Blnk {
         return this.formatResponse<R>(
           response.status,
           `Success`,
-          jsonResponse,
+          jsonResponse as R,
         ) as ApiResponse<R>;
       } catch (error: unknown) {
         if (error instanceof Error && error.name === `AbortError`) {


### PR DESCRIPTION
## Summary
- Fixes the TypeScript compile error blocking the npm publish workflow for v1.3.0
- Casts parsed JSON response bodies to `R` when passing them to `formatResponse`, matching the existing `null as R` pattern used for 204/205 responses

## Context
The publish workflow failed at `npm run compile` with:
```
src/blnk/endpoints/baseBlnkClient.ts(231,11): error TS2345: Argument of type 'R | null' is not assignable to parameter of type 'R'.
```

## Test plan
- [x] `npm run compile` passes locally
- [ ] Merge to `main`
- [ ] Re-run the failed **Publish to npm** workflow for tag `v1.3.0`
- [ ] Approve `npm-publish` deployment if prompted
- [ ] Verify `npm view @blnkfinance/blnk-typescript version` returns `1.3.0`