### PR TITLE
ci(publish): disable tap coverage in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm run compile
 
       - name: Run unit tests
-        run: npm run test:unit
+        run: npx tap tests/unit --disable-coverage
 
       - name: Run linter
         run: npm run lint


### PR DESCRIPTION
## Summary
- Run unit tests in the publish workflow with `--disable-coverage` so tap does not fail when coverage is not generated in CI

## Context
The v1.3.0 publish run passed compile and all 1056 unit tests, but failed with exit code 1 because tap reported `No coverage generated`.

## Test plan
- [ ] Merge to `main`
- [ ] Move tag `v1.3.0` to latest `main` and approve `npm-publish`
- [ ] Verify `npm view @blnkfinance/blnk-typescript version` returns `1.3.0`