### PR TITLE
fix(lint): satisfy gts checks blocking npm publish workflow

### DIFF
--- a/src/blnk/endpoints/baseBlnkClient.ts
+++ b/src/blnk/endpoints/baseBlnkClient.ts
@@ -222,8 +222,7 @@ export class Blnk {
           ) as ApiResponse<R>;
         }
 
-        let jsonResponse: R | null;
-        jsonResponse = (await readResponseJsonBody(response)) as R | null;
+        const jsonResponse = (await readResponseJsonBody(response)) as R | null;
 
         return this.formatResponse<R>(
           response.status,

--- a/src/blnk/utils/requestRetry.ts
+++ b/src/blnk/utils/requestRetry.ts
@@ -31,7 +31,9 @@ export function normalizeRetryCount(retryCount: number | undefined): number {
   return Math.floor(retryCount);
 }
 
-export function normalizeRetryDelayMs(retryDelayMs: number | undefined): number {
+export function normalizeRetryDelayMs(
+  retryDelayMs: number | undefined,
+): number {
   if (
     retryDelayMs === undefined ||
     !Number.isFinite(retryDelayMs) ||

--- a/tests/integration/sdk-issues.integration.test.ts
+++ b/tests/integration/sdk-issues.integration.test.ts
@@ -15,7 +15,12 @@ import {
   BulkTransactions,
   CreateTransactions,
 } from "../../src/types/transactions";
-import {BASE_URL, BLNK_API_KEY, GenerateRandomNumbersWithPrefix, Sleep} from "../utils.test";
+import {
+  BASE_URL,
+  BLNK_API_KEY,
+  GenerateRandomNumbersWithPrefix,
+  Sleep,
+} from "../utils.test";
 
 const clientOptions: BlnkClientOptions = {baseUrl: BASE_URL};
 const client = BlnkInit(BLNK_API_KEY, clientOptions);

--- a/tests/unit/blnk/endpoints/apiKeys.test.ts
+++ b/tests/unit/blnk/endpoints/apiKeys.test.ts
@@ -359,35 +359,32 @@ tap.test(`Issue #38 — ApiKeys.delete`, async t => {
     },
   );
 
-  t.test(
-    `Issue #118 — delete succeeds on 200 OK with empty body`,
-    async tt => {
-      const emptyBodyFetch = async () =>
-        ({
-          ok: true,
-          status: 200,
-          statusText: `OK`,
-          json: async () => {
-            throw new SyntaxError(`Unexpected end of JSON input`);
-          },
-          text: async () => ``,
-          headers: new Headers(),
-        }) as unknown as Response;
+  t.test(`Issue #118 — delete succeeds on 200 OK with empty body`, async tt => {
+    const emptyBodyFetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: `OK`,
+        json: async () => {
+          throw new SyntaxError(`Unexpected end of JSON input`);
+        },
+        text: async () => ``,
+        headers: new Headers(),
+      }) as unknown as Response;
 
-      const blnk = new Blnk(
-        `test-key`,
-        createMockBlnkClientOptions(),
-        {ApiKeys},
-        FormatResponse,
-        emptyBodyFetch,
-      );
+    const blnk = new Blnk(
+      `test-key`,
+      createMockBlnkClientOptions(),
+      {ApiKeys},
+      FormatResponse,
+      emptyBodyFetch,
+    );
 
-      const response = await blnk.ApiKeys.delete(`api_key_test_123`);
+    const response = await blnk.ApiKeys.delete(`api_key_test_123`);
 
-      tt.equal(response.status, 200);
-      tt.equal(response.message, `Success`);
-      tt.equal(response.data, null);
-      tt.end();
-    },
-  );
+    tt.equal(response.status, 200);
+    tt.equal(response.message, `Success`);
+    tt.equal(response.data, null);
+    tt.end();
+  });
 });

--- a/tests/unit/blnk/endpoints/balanceMonitorDelete.test.ts
+++ b/tests/unit/blnk/endpoints/balanceMonitorDelete.test.ts
@@ -105,35 +105,32 @@ tap.test(`Issue #120 — BalanceMonitor.delete`, async t => {
     tt.end();
   });
 
-  t.test(
-    `Issue #118 — delete succeeds on 200 OK with empty body`,
-    async tt => {
-      const emptyBodyFetch = async () =>
-        ({
-          ok: true,
-          status: 200,
-          statusText: `OK`,
-          json: async () => {
-            throw new SyntaxError(`Unexpected end of JSON input`);
-          },
-          text: async () => ``,
-          headers: new Headers(),
-        }) as unknown as Response;
+  t.test(`Issue #118 — delete succeeds on 200 OK with empty body`, async tt => {
+    const emptyBodyFetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: `OK`,
+        json: async () => {
+          throw new SyntaxError(`Unexpected end of JSON input`);
+        },
+        text: async () => ``,
+        headers: new Headers(),
+      }) as unknown as Response;
 
-      const blnk = new Blnk(
-        `test-key`,
-        createMockBlnkClientOptions(),
-        {BalanceMonitor},
-        FormatResponse,
-        emptyBodyFetch,
-      );
+    const blnk = new Blnk(
+      `test-key`,
+      createMockBlnkClientOptions(),
+      {BalanceMonitor},
+      FormatResponse,
+      emptyBodyFetch,
+    );
 
-      const response = await blnk.BalanceMonitor.delete(`mon_test_123`);
+    const response = await blnk.BalanceMonitor.delete(`mon_test_123`);
 
-      tt.equal(response.status, 200);
-      tt.equal(response.message, `Success`);
-      tt.equal(response.data, null);
-      tt.end();
-    },
-  );
+    tt.equal(response.status, 200);
+    tt.equal(response.message, `Success`);
+    tt.equal(response.data, null);
+    tt.end();
+  });
 });

--- a/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
+++ b/tests/unit/blnk/endpoints/baseBlnkClient.test.ts
@@ -354,50 +354,47 @@ tap.test(`Blnk SDK tests`, t => {
     },
   );
 
-  t.test(
-    `Issue #118 — attaches error_detail.code on 423 Locked`,
-    async tt => {
-      const lockedFetch = async () =>
-        ({
-          ok: false,
-          status: 423,
-          statusText: `Locked`,
-          json: async () => ({
+  t.test(`Issue #118 — attaches error_detail.code on 423 Locked`, async tt => {
+    const lockedFetch = async () =>
+      ({
+        ok: false,
+        status: 423,
+        statusText: `Locked`,
+        json: async () => ({
+          error: `resource locked`,
+          error_detail: {
+            code: `GEN_LOCKED`,
+            message: `resource locked`,
+          },
+        }),
+        text: async () =>
+          JSON.stringify({
             error: `resource locked`,
             error_detail: {
               code: `GEN_LOCKED`,
               message: `resource locked`,
             },
           }),
-          text: async () =>
-            JSON.stringify({
-              error: `resource locked`,
-              error_detail: {
-                code: `GEN_LOCKED`,
-                message: `resource locked`,
-              },
-            }),
-          headers: new Headers(),
-        }) as Response;
+        headers: new Headers(),
+      }) as Response;
 
-      const lockedBlnk = new Blnk(
-        apiKey,
-        options,
-        mockServices,
-        FormatResponse,
-        lockedFetch,
-      );
+    const lockedBlnk = new Blnk(
+      apiKey,
+      options,
+      mockServices,
+      FormatResponse,
+      lockedFetch,
+    );
 
-      const result = await lockedBlnk[`request`](`balances/bln_test`, {}, `PUT`);
+    const result = await lockedBlnk[`request`](`balances/bln_test`, {}, `PUT`);
 
-      tt.equal(result.status, 423);
-      tt.same(result.error, {
-        code: `GEN_LOCKED`,
-        message: `resource locked`,
-      });
-      tt.end();
-    },
-  );
+    tt.equal(result.status, 423);
+    tt.same(result.error, {
+      code: `GEN_LOCKED`,
+      message: `resource locked`,
+    });
+    tt.end();
+  });
 
   t.test(`request passes AbortSignal for timeout`, async tt => {
     const signalFetch = async (

--- a/tests/unit/blnk/endpoints/hooks.test.ts
+++ b/tests/unit/blnk/endpoints/hooks.test.ts
@@ -379,35 +379,32 @@ tap.test(`Issue #32 — Hooks.delete`, async t => {
     tt.end();
   });
 
-  t.test(
-    `Issue #118 — delete succeeds on 200 OK with empty body`,
-    async tt => {
-      const emptyBodyFetch = async () =>
-        ({
-          ok: true,
-          status: 200,
-          statusText: `OK`,
-          json: async () => {
-            throw new SyntaxError(`Unexpected end of JSON input`);
-          },
-          text: async () => ``,
-          headers: new Headers(),
-        }) as unknown as Response;
+  t.test(`Issue #118 — delete succeeds on 200 OK with empty body`, async tt => {
+    const emptyBodyFetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: `OK`,
+        json: async () => {
+          throw new SyntaxError(`Unexpected end of JSON input`);
+        },
+        text: async () => ``,
+        headers: new Headers(),
+      }) as unknown as Response;
 
-      const blnk = new Blnk(
-        `test-key`,
-        createMockBlnkClientOptions(),
-        {Hooks},
-        FormatResponse,
-        emptyBodyFetch,
-      );
+    const blnk = new Blnk(
+      `test-key`,
+      createMockBlnkClientOptions(),
+      {Hooks},
+      FormatResponse,
+      emptyBodyFetch,
+    );
 
-      const response = await blnk.Hooks.delete(`hk_test_123`);
+    const response = await blnk.Hooks.delete(`hk_test_123`);
 
-      tt.equal(response.status, 200);
-      tt.equal(response.message, `Success`);
-      tt.equal(response.data, null);
-      tt.end();
-    },
-  );
+    tt.equal(response.status, 200);
+    tt.equal(response.message, `Success`);
+    tt.equal(response.data, null);
+    tt.end();
+  });
 });

--- a/tests/unit/blnk/endpoints/identityDelete.test.ts
+++ b/tests/unit/blnk/endpoints/identityDelete.test.ts
@@ -89,35 +89,32 @@ tap.test(`Issue #116 — Identity.delete`, async t => {
     tt.end();
   });
 
-  t.test(
-    `Issue #118 — delete succeeds on 200 OK with empty body`,
-    async tt => {
-      const emptyBodyFetch = async () =>
-        ({
-          ok: true,
-          status: 200,
-          statusText: `OK`,
-          json: async () => {
-            throw new SyntaxError(`Unexpected end of JSON input`);
-          },
-          text: async () => ``,
-          headers: new Headers(),
-        }) as unknown as Response;
+  t.test(`Issue #118 — delete succeeds on 200 OK with empty body`, async tt => {
+    const emptyBodyFetch = async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: `OK`,
+        json: async () => {
+          throw new SyntaxError(`Unexpected end of JSON input`);
+        },
+        text: async () => ``,
+        headers: new Headers(),
+      }) as unknown as Response;
 
-      const blnk = new Blnk(
-        `test-key`,
-        createMockBlnkClientOptions(),
-        {Identity},
-        FormatResponse,
-        emptyBodyFetch,
-      );
+    const blnk = new Blnk(
+      `test-key`,
+      createMockBlnkClientOptions(),
+      {Identity},
+      FormatResponse,
+      emptyBodyFetch,
+    );
 
-      const response = await blnk.Identity.delete(`idt_test_123`);
+    const response = await blnk.Identity.delete(`idt_test_123`);
 
-      tt.equal(response.status, 200);
-      tt.equal(response.message, `Success`);
-      tt.equal(response.data, null);
-      tt.end();
-    },
-  );
+    tt.equal(response.status, 200);
+    tt.equal(response.message, `Success`);
+    tt.equal(response.data, null);
+    tt.end();
+  });
 });

--- a/tests/unit/blnk/endpoints/identityDetokenizeField.test.ts
+++ b/tests/unit/blnk/endpoints/identityDetokenizeField.test.ts
@@ -11,47 +11,61 @@ const mockResponse: DetokenizeIdentityFieldResp = {
 };
 
 tap.test(`Issue #25 — Identity.detokenizeField`, async t => {
-  t.test(`detokenizeField GETs identities/{id}/detokenize/{field}`, async tt => {
-    const mockLogger = createMockLogger();
-    const thirdPartyRequest = async <R>() => ({
-      status: 200,
-      message: `Success`,
-      data: mockResponse as unknown as R,
-    });
-    const capturedRequest = tt.captureFn(thirdPartyRequest);
-    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+  t.test(
+    `detokenizeField GETs identities/{id}/detokenize/{field}`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: mockResponse as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const identity = new Identity(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
 
-    const response = await identity.detokenizeField(
-      `idt_test_123`,
-      `EmailAddress`,
-    );
+      const response = await identity.detokenizeField(
+        `idt_test_123`,
+        `EmailAddress`,
+      );
 
-    tt.match(capturedRequest.args(), [
-      [`identities/idt_test_123/detokenize/EmailAddress`, null, `GET`],
-    ]);
-    tt.equal(response.status, 200);
-    tt.equal(response.data?.field, `EmailAddress`);
-    tt.equal(response.data?.value, `jane@example.com`);
-    tt.end();
-  });
+      tt.match(capturedRequest.args(), [
+        [`identities/idt_test_123/detokenize/EmailAddress`, null, `GET`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.equal(response.data?.field, `EmailAddress`);
+      tt.equal(response.data?.value, `jane@example.com`);
+      tt.end();
+    },
+  );
 
-  t.test(`detokenizeField uses PascalCase struct field name in path`, async tt => {
-    const mockLogger = createMockLogger();
-    const thirdPartyRequest = async <R>() => ({
-      status: 200,
-      message: `Success`,
-      data: {field: `FirstName`, value: `Jane`} as unknown as R,
-    });
-    const capturedRequest = tt.captureFn(thirdPartyRequest);
-    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+  t.test(
+    `detokenizeField uses PascalCase struct field name in path`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: {field: `FirstName`, value: `Jane`} as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const identity = new Identity(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
 
-    await identity.detokenizeField(`idt_test_123`, `FirstName`);
+      await identity.detokenizeField(`idt_test_123`, `FirstName`);
 
-    tt.match(capturedRequest.args(), [
-      [`identities/idt_test_123/detokenize/FirstName`, null, `GET`],
-    ]);
-    tt.end();
-  });
+      tt.match(capturedRequest.args(), [
+        [`identities/idt_test_123/detokenize/FirstName`, null, `GET`],
+      ]);
+      tt.end();
+    },
+  );
 
   t.test(`detokenizeField rejects empty identity id`, async tt => {
     const mockLogger = createMockLogger();

--- a/tests/unit/blnk/endpoints/identityGetTokenizedFields.test.ts
+++ b/tests/unit/blnk/endpoints/identityGetTokenizedFields.test.ts
@@ -10,46 +10,60 @@ const mockResponse: GetTokenizedFieldsResp = {
 };
 
 tap.test(`Issue #24 — Identity.getTokenizedFields`, async t => {
-  t.test(`getTokenizedFields GETs identities/{id}/tokenized-fields`, async tt => {
-    const mockLogger = createMockLogger();
-    const thirdPartyRequest = async <R>() => ({
-      status: 200,
-      message: `Success`,
-      data: mockResponse as unknown as R,
-    });
-    const capturedRequest = tt.captureFn(thirdPartyRequest);
-    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+  t.test(
+    `getTokenizedFields GETs identities/{id}/tokenized-fields`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: mockResponse as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const identity = new Identity(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
 
-    const response = await identity.getTokenizedFields(`idt_test_123`);
+      const response = await identity.getTokenizedFields(`idt_test_123`);
 
-    tt.match(capturedRequest.args(), [
-      [`identities/idt_test_123/tokenized-fields`, null, `GET`],
-    ]);
-    tt.equal(response.status, 200);
-    tt.same(response.data?.tokenized_fields, mockResponse.tokenized_fields);
-    tt.end();
-  });
+      tt.match(capturedRequest.args(), [
+        [`identities/idt_test_123/tokenized-fields`, null, `GET`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.same(response.data?.tokenized_fields, mockResponse.tokenized_fields);
+      tt.end();
+    },
+  );
 
-  t.test(`getTokenizedFields returns empty list for fresh identity`, async tt => {
-    const mockLogger = createMockLogger();
-    const emptyResponse: GetTokenizedFieldsResp = {tokenized_fields: []};
-    const thirdPartyRequest = async <R>() => ({
-      status: 200,
-      message: `Success`,
-      data: emptyResponse as unknown as R,
-    });
-    const capturedRequest = tt.captureFn(thirdPartyRequest);
-    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+  t.test(
+    `getTokenizedFields returns empty list for fresh identity`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const emptyResponse: GetTokenizedFieldsResp = {tokenized_fields: []};
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: emptyResponse as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const identity = new Identity(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
 
-    const response = await identity.getTokenizedFields(`idt_test_123`);
+      const response = await identity.getTokenizedFields(`idt_test_123`);
 
-    tt.match(capturedRequest.args(), [
-      [`identities/idt_test_123/tokenized-fields`, null, `GET`],
-    ]);
-    tt.equal(response.status, 200);
-    tt.same(response.data?.tokenized_fields, []);
-    tt.end();
-  });
+      tt.match(capturedRequest.args(), [
+        [`identities/idt_test_123/tokenized-fields`, null, `GET`],
+      ]);
+      tt.equal(response.status, 200);
+      tt.same(response.data?.tokenized_fields, []);
+      tt.end();
+    },
+  );
 
   t.test(`getTokenizedFields rejects empty identity id`, async tt => {
     const mockLogger = createMockLogger();

--- a/tests/unit/blnk/endpoints/identityTokenizeField.test.ts
+++ b/tests/unit/blnk/endpoints/identityTokenizeField.test.ts
@@ -30,23 +30,30 @@ tap.test(`Issue #22 — Identity.tokenizeField`, async t => {
     tt.end();
   });
 
-  t.test(`tokenizeField uses PascalCase struct field name in path`, async tt => {
-    const mockLogger = createMockLogger();
-    const thirdPartyRequest = async <R>() => ({
-      status: 200,
-      message: `Success`,
-      data: mockResponse as unknown as R,
-    });
-    const capturedRequest = tt.captureFn(thirdPartyRequest);
-    const identity = new Identity(capturedRequest, mockLogger, FormatResponse);
+  t.test(
+    `tokenizeField uses PascalCase struct field name in path`,
+    async tt => {
+      const mockLogger = createMockLogger();
+      const thirdPartyRequest = async <R>() => ({
+        status: 200,
+        message: `Success`,
+        data: mockResponse as unknown as R,
+      });
+      const capturedRequest = tt.captureFn(thirdPartyRequest);
+      const identity = new Identity(
+        capturedRequest,
+        mockLogger,
+        FormatResponse,
+      );
 
-    await identity.tokenizeField(`idt_test_123`, `EmailAddress`);
+      await identity.tokenizeField(`idt_test_123`, `EmailAddress`);
 
-    tt.match(capturedRequest.args(), [
-      [`identities/idt_test_123/tokenize/EmailAddress`, null, `POST`],
-    ]);
-    tt.end();
-  });
+      tt.match(capturedRequest.args(), [
+        [`identities/idt_test_123/tokenize/EmailAddress`, null, `POST`],
+      ]);
+      tt.end();
+    },
+  );
 
   t.test(`tokenizeField rejects empty identity id`, async tt => {
     const mockLogger = createMockLogger();

--- a/tests/unit/blnk/endpoints/transactions.test.ts
+++ b/tests/unit/blnk/endpoints/transactions.test.ts
@@ -1247,15 +1247,18 @@ tap.test(`Creates bulk transactions`, async t => {
       );
 
       const data: BulkTransactions<meta_dataT> = {
-        transactions: Array.from({length: MAX_BULK_CREATE_ITEMS + 1}, (_, i) => ({
-          amount: 1000,
-          currency: `USD`,
-          description: `Bulk txn ${i}`,
-          precision: 100,
-          reference: `bulk_max_ref_${i}`,
-          source: `@source_account`,
-          destination: `@destination_account`,
-        })),
+        transactions: Array.from(
+          {length: MAX_BULK_CREATE_ITEMS + 1},
+          (_, i) => ({
+            amount: 1000,
+            currency: `USD`,
+            description: `Bulk txn ${i}`,
+            precision: 100,
+            reference: `bulk_max_ref_${i}`,
+            source: `@source_account`,
+            destination: `@destination_account`,
+          }),
+        ),
       };
 
       const response = await transactions.createBulk<meta_dataT>(data);
@@ -1264,9 +1267,7 @@ tap.test(`Creates bulk transactions`, async t => {
       childTest.equal(response.status, 400);
       childTest.match(
         response.message,
-        new RegExp(
-          `Too many transactions; max is ${MAX_BULK_CREATE_ITEMS}\\.`,
-        ),
+        new RegExp(`Too many transactions; max is ${MAX_BULK_CREATE_ITEMS}\\.`),
       );
       childTest.end();
     },

--- a/tests/unit/blnk/utils/identityDetokenizeValidators.test.ts
+++ b/tests/unit/blnk/utils/identityDetokenizeValidators.test.ts
@@ -9,10 +9,7 @@ tap.test(`ValidateDetokenizeIdentityData`, async t => {
   };
 
   t.equal(ValidateDetokenizeIdentityData(`idt_test_123`, validData), null);
-  t.equal(
-    ValidateDetokenizeIdentityData(`idt_test_123`, {fields: []}),
-    null,
-  );
+  t.equal(ValidateDetokenizeIdentityData(`idt_test_123`, {fields: []}), null);
   t.equal(
     ValidateDetokenizeIdentityData(``, validData),
     `identity id is required`,

--- a/tests/unit/blnk/utils/transactionValidators.test.ts
+++ b/tests/unit/blnk/utils/transactionValidators.test.ts
@@ -1020,25 +1020,32 @@ tap.test(`Issue #15 — bulkCommitInflight validation`, t => {
   t.test(`allows skip_queue on bulk commit payloads (issue #117)`, tt => {
     const data: BulkCommitInflightRequest = {
       skip_queue: true,
-      transactions: [{transaction_id: `txn_11111111-1111-4111-8111-111111111111`}],
+      transactions: [
+        {transaction_id: `txn_11111111-1111-4111-8111-111111111111`},
+      ],
     };
 
     tt.equal(ValidateBulkCommitInflight(data), null);
     tt.end();
   });
 
-  t.test(`rejects invalid skip_queue on bulk commit payloads (issue #117)`, tt => {
-    const data = {
-      skip_queue: `true`,
-      transactions: [{transaction_id: `txn_11111111-1111-4111-8111-111111111111`}],
-    } as unknown as BulkCommitInflightRequest;
+  t.test(
+    `rejects invalid skip_queue on bulk commit payloads (issue #117)`,
+    tt => {
+      const data = {
+        skip_queue: `true`,
+        transactions: [
+          {transaction_id: `txn_11111111-1111-4111-8111-111111111111`},
+        ],
+      } as unknown as BulkCommitInflightRequest;
 
-    tt.equal(
-      ValidateBulkCommitInflight(data),
-      `skip_queue must be a boolean if provided.`,
-    );
-    tt.end();
-  });
+      tt.equal(
+        ValidateBulkCommitInflight(data),
+        `skip_queue must be a boolean if provided.`,
+      );
+      tt.end();
+    },
+  );
 
   t.end();
 });
@@ -1095,18 +1102,21 @@ tap.test(`Issue #16 — bulkVoidInflight validation`, t => {
     tt.end();
   });
 
-  t.test(`rejects invalid skip_queue on bulk void payloads (issue #117)`, tt => {
-    const data = {
-      skip_queue: `true`,
-      transaction_ids: [`txn_11111111-1111-4111-8111-111111111111`],
-    } as unknown as BulkVoidInflightRequest;
+  t.test(
+    `rejects invalid skip_queue on bulk void payloads (issue #117)`,
+    tt => {
+      const data = {
+        skip_queue: `true`,
+        transaction_ids: [`txn_11111111-1111-4111-8111-111111111111`],
+      } as unknown as BulkVoidInflightRequest;
 
-    tt.equal(
-      ValidateBulkVoidInflight(data),
-      `skip_queue must be a boolean if provided.`,
-    );
-    tt.end();
-  });
+      tt.equal(
+        ValidateBulkVoidInflight(data),
+        `skip_queue must be a boolean if provided.`,
+      );
+      tt.end();
+    },
+  );
 
   t.end();
 });

--- a/tests/unit/types/droppedResponseFields.test.ts
+++ b/tests/unit/types/droppedResponseFields.test.ts
@@ -32,26 +32,29 @@ tap.test(`Issue #122 — Core 0.15.0 dropped response fields`, t => {
     tt.end();
   });
 
-  t.test(`CreateLedgerBalanceResp accepts response without currency_multiplier`, tt => {
-    const response: CreateLedgerBalanceResp<Record<string, never>> = {
-      balance: 0,
-      version: 0,
-      inflight_balance: 0,
-      credit_balance: 0,
-      inflight_credit_balance: 0,
-      debit_balance: 0,
-      inflight_debit_balance: 0,
-      ledger_id: `ldg_test`,
-      identity_id: ``,
-      balance_id: `bln_test`,
-      indicator: ``,
-      currency: `USD`,
-      created_at: `2026-06-24T00:00:00Z`,
-    };
+  t.test(
+    `CreateLedgerBalanceResp accepts response without currency_multiplier`,
+    tt => {
+      const response: CreateLedgerBalanceResp<Record<string, never>> = {
+        balance: 0,
+        version: 0,
+        inflight_balance: 0,
+        credit_balance: 0,
+        inflight_credit_balance: 0,
+        debit_balance: 0,
+        inflight_debit_balance: 0,
+        ledger_id: `ldg_test`,
+        identity_id: ``,
+        balance_id: `bln_test`,
+        indicator: ``,
+        currency: `USD`,
+        created_at: `2026-06-24T00:00:00Z`,
+      };
 
-    tt.equal(response.currency_multiplier, undefined);
-    tt.end();
-  });
+      tt.equal(response.currency_multiplier, undefined);
+      tt.end();
+    },
+  );
 
   t.test(`SearchTransactionDocument omits rate`, tt => {
     const document: SearchTransactionDocument = {


### PR DESCRIPTION
## Summary
- Applies `gts fix` / prettier formatting across unit tests and related files that failed CI lint
- Changes `jsonResponse` to `const` in `baseBlnkClient.ts` (fixes `prefer-const` from PR #134)

## Context
The v1.3.0 publish workflow passed compile and unit tests after PR #135, but failed at **Run linter** with prettier/eslint errors.

## Local publish pipeline verification
All publish workflow steps were run locally before opening this PR:
- [x] `npm run compile`
- [x] `npx tap tests/unit --disable-coverage` (1056 tests pass)
- [x] `npm run lint` (0 errors; warnings only)
- [x] `npm pack --dry-run`
- [x] Smoke test: install packed tarball + `require('@blnkfinance/blnk-typescript')`

## After merge
1. Move tag `v1.3.0` to latest `main`
2. Approve `npm-publish` in GitHub Actions
3. Verify `npm view @blnkfinance/blnk-typescript version` → `1.3.0`

## Remaining publish risks (checked)
- **NPM_TOKEN**: must have bypass 2FA enabled on `blnk-ts` repo (same token as CLI)
- **Tag ref**: must point at merged `main`, not an older commit
- **Environment approval**: `npm-publish` protection rule still requires manual approval