### PR TITLE
feat: add with_queued to LedgerBalances.get

### DIFF
--- a/src/blnk/endpoints/ledgerBalances.ts
+++ b/src/blnk/endpoints/ledgerBalances.ts
@@ -101,6 +101,8 @@ export class LedgerBalances {
    *
    * Pass `{ from_source: true }` to reconstruct the balance from transactions
    * instead of snapshots (`GET /balances/{balance_id}?from_source=true`).
+   * Pass `{ with_queued: true }` to include queued credit and debit balances
+   * (`GET /balances/{balance_id}?with_queued=true`).
    *
    * @see https://docs.blnkfinance.com/reference/balance-from-source
    *
@@ -123,8 +125,15 @@ export class LedgerBalances {
       }
 
       let endpoint = `balances/${id}`;
+      const queryParams: string[] = [];
       if (options?.from_source) {
-        endpoint += `?from_source=true`;
+        queryParams.push(`from_source=true`);
+      }
+      if (options?.with_queued) {
+        queryParams.push(`with_queued=true`);
+      }
+      if (queryParams.length > 0) {
+        endpoint += `?${queryParams.join(`&`)}`;
       }
 
       const response = await this.request<

--- a/src/blnk/utils/validators/ledgerBalance.ts
+++ b/src/blnk/utils/validators/ledgerBalance.ts
@@ -119,6 +119,10 @@ export function ValidateGetBalance(data: GetBalanceRequest): null | string {
     return `from_source must be a boolean if provided`;
   }
 
+  if (data.with_queued !== undefined && typeof data.with_queued !== `boolean`) {
+    return `with_queued must be a boolean if provided`;
+  }
+
   return null;
 }
 

--- a/src/types/ledgerBalances.ts
+++ b/src/types/ledgerBalances.ts
@@ -94,6 +94,8 @@ export interface HistoricalBalanceDetails {
 export interface GetBalanceRequest {
   /** Reconstruct balance from transactions instead of snapshots when true. */
   from_source?: boolean;
+  /** Include queued credit and debit balances when true. */
+  with_queued?: boolean;
 }
 
 /** Options for `GET /balances/{balance_id}/at`. */

--- a/tests/unit/blnk/endpoints/ledgerBalances.test.ts
+++ b/tests/unit/blnk/endpoints/ledgerBalances.test.ts
@@ -536,6 +536,63 @@ tap.test(`Ledger Balance Tests`, t => {
     tt.end();
   });
 
+  t.test(`get forwards with_queued query param`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    await ledgerBalance.get(balanceId, {with_queued: true});
+
+    tt.match(capturedRequest.args(), [
+      [`balances/${balanceId}?with_queued=true`, undefined, `GET`],
+    ]);
+    tt.end();
+  });
+
+  t.test(`get forwards from_source and with_queued query params`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    const balanceId = `bln_5ce86029-3c2e-4e2a-aae2-7fb931ca4c4f`;
+    await ledgerBalance.get(balanceId, {from_source: true, with_queued: true});
+
+    tt.match(capturedRequest.args(), [
+      [
+        `balances/${balanceId}?from_source=true&with_queued=true`,
+        undefined,
+        `GET`,
+      ],
+    ]);
+    tt.end();
+  });
+
+  t.test(`get rejects invalid with_queued`, async tt => {
+    const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
+    const capturedRequest = tt.captureFn(thirdPartyRequest);
+    const ledgerBalance = new LedgerBalances(
+      capturedRequest,
+      mockLogger,
+      FormatResponse,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await ledgerBalance.get(`bln_123`, {
+      with_queued: `true`,
+    } as any);
+
+    tt.match(capturedRequest.args(), []);
+    tt.equal(response.status, 400);
+    tt.equal(response.message, `with_queued must be a boolean if provided`);
+    tt.end();
+  });
+
   t.test(`getAt calls GET /balances/{id}/at (issue #11)`, async tt => {
     const thirdPartyRequest = createMockBlnkRequest(true, undefined, 200);
     const capturedRequest = tt.captureFn(thirdPartyRequest);

--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -147,6 +147,19 @@ tap.test(`Issue #48 — ValidateGetBalance`, t => {
     tt.end();
   });
 
+  t.test(`accepts with_queued flag`, tt => {
+    tt.equal(ValidateGetBalance({with_queued: true}), null);
+    tt.end();
+  });
+
+  t.test(`accepts from_source and with_queued flags`, tt => {
+    tt.equal(
+      ValidateGetBalance({from_source: true, with_queued: true}),
+      null,
+    );
+    tt.end();
+  });
+
   t.test(`accepts empty options object`, tt => {
     tt.equal(ValidateGetBalance({}), null);
     tt.end();
@@ -157,6 +170,15 @@ tap.test(`Issue #48 — ValidateGetBalance`, t => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ValidateGetBalance({from_source: `true` as any}),
       `from_source must be a boolean if provided`,
+    );
+    tt.end();
+  });
+
+  t.test(`rejects non-boolean with_queued`, tt => {
+    tt.equal(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ValidateGetBalance({with_queued: `true` as any}),
+      `with_queued must be a boolean if provided`,
     );
     tt.end();
   });


### PR DESCRIPTION
## Summary
- Add `with_queued?: boolean` to `GetBalanceRequest` for `LedgerBalances.get`
- Validate `with_queued` as a boolean in `ValidateGetBalance`
- Build query strings for `from_source` and/or `with_queued` (joined with `&` when both are set)
- Add unit tests for endpoint forwarding and validator behavior

## Test plan
- [x] `./node_modules/.bin/tap --disable-coverage --jobs=1 --timeout=120 tests/unit/blnk/utils/ledgerBalanceValidators.test.ts tests/unit/blnk/endpoints/ledgerBalances.test.ts` — 120/120 pass