### PR TITLE
fix(lint): prettier formatting in ledger balance validators test

### DIFF
--- a/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
+++ b/tests/unit/blnk/utils/ledgerBalanceValidators.test.ts
@@ -153,10 +153,7 @@ tap.test(`Issue #48 — ValidateGetBalance`, t => {
   });
 
   t.test(`accepts from_source and with_queued flags`, tt => {
-    tt.equal(
-      ValidateGetBalance({from_source: true, with_queued: true}),
-      null,
-    );
+    tt.equal(ValidateGetBalance({from_source: true, with_queued: true}), null);
     tt.end();
   });
 


### PR DESCRIPTION
## Summary
- Fix Prettier formatting in `tests/unit/blnk/utils/ledgerBalanceValidators.test.ts`
- Unblocks `npm run lint` (needed for the tag-based npm publish workflow)

No SDK behavior or version bump.

## Test plan
- [x] `npm run lint` no longer reports the prettier error on this file
- [ ] Confirm CI/lint is clean on the PR if checks are available