### PR TITLE
fix(errors): omit undefined details from parseBlnkApiErrorBody

### DIFF
--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -21,11 +21,14 @@ export function parseBlnkApiErrorBody(
   if (errorDetail && typeof errorDetail === `object`) {
     const detail = errorDetail as Record<string, unknown>;
     if (typeof detail.code === `string` && typeof detail.message === `string`) {
-      return {
+      const parsed: BlnkApiErrorDetail = {
         code: detail.code,
         message: detail.message,
-        details: detail.details,
       };
+      if (`details` in detail) {
+        parsed.details = detail.details;
+      }
+      return parsed;
     }
   }
 

--- a/tests/unit/blnk/utils/apiErrors.test.ts
+++ b/tests/unit/blnk/utils/apiErrors.test.ts
@@ -21,6 +21,26 @@ tap.test(`parseBlnkApiErrorBody`, t => {
     tt.end();
   });
 
+  t.test(
+    `omits details when error_detail has no details field (issue #132)`,
+    tt => {
+      const parsed = parseBlnkApiErrorBody({
+        error: `bad request`,
+        error_detail: {
+          code: `GEN_BAD_REQUEST`,
+          message: `bad request`,
+        },
+      });
+
+      tt.same(parsed, {
+        code: `GEN_BAD_REQUEST`,
+        message: `bad request`,
+      });
+      tt.equal(parsed && `details` in parsed, false);
+      tt.end();
+    },
+  );
+
   t.test(`falls back to legacy error string`, tt => {
     const parsed = parseBlnkApiErrorBody({error: `invalid request`});
     tt.same(parsed, {code: `UNKNOWN`, message: `invalid request`});


### PR DESCRIPTION
## Summary
- Only include `details` on `parseBlnkApiErrorBody` results when `error_detail.details` is present
- Add regression coverage for missing `details` (issue #132)
- Completes the remaining half of [#132](https://github.com/blnkfinance/blnk-ts/issues/132); the `baseBlnkClient` `tsc` cast was already fixed on main

No npm version bump.

## Test plan
- [x] `npm run compile`
- [x] `tap tests/unit/blnk/utils/apiErrors.test.ts tests/unit/blnk/endpoints/baseBlnkClient.test.ts` — 77/77 passed
- [x] `npm run lint` — 0 errors